### PR TITLE
fix: update CI runner labels to match available runners

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -8,7 +8,7 @@ jobs:
   review:
     name: AI Code Review
     if: github.event.pull_request.draft == false
-    runs-on: [self-hosted, builder]
+    runs-on: [self-hosted, Linux, X64]
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: [self-hosted, builder]
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Why

Organization runners only have `self-hosted/Linux/X64` labels, not `builder`. Workflows using `[self-hosted, builder]` remain queued indefinitely.

## What

- Update `runs-on` in both workflow files from `[self-hosted, builder]` to `[self-hosted, Linux, X64]`
- `.github/workflows/opencode-review.yml`
- `.github/workflows/pytest.yml`

## Testing

- Runner labels match available org runners (self-hosted + Linux + X64)
- No code logic changes