### PR TITLE
feat: show pull request link on run detail page

### DIFF
--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -315,7 +315,7 @@ async def run_detail(request: Request, run_id: str) -> HTMLResponse:
     with connect_db() as conn:
         row = conn.execute(
             """
-            SELECT id, status, created_at, updated_at, logs_path
+            SELECT id, repo, pr_number, status, created_at, updated_at, logs_path
             FROM autofix_runs
             WHERE id = ?
             """,
@@ -324,14 +324,22 @@ async def run_detail(request: Request, run_id: str) -> HTMLResponse:
 
     run = {
         "id": run_id,
+        "repo": "-",
+        "pr_number": "-",
+        "pr_url": None,
         "status": "not_found",
         "created_at": "-",
         "updated_at": "-",
         "log_preview": "No log data yet.",
     }
     if row is not None:
+        repo = str(row["repo"])
+        pr_number = str(row["pr_number"])
         run = {
             "id": str(row["id"]),
+            "repo": repo,
+            "pr_number": pr_number,
+            "pr_url": f"https://github.com/{repo}/pull/{pr_number}",
             "status": str(row["status"]),
             "created_at": str(row["created_at"]),
             "updated_at": str(row["updated_at"]),

--- a/app/templates/run_detail.html
+++ b/app/templates/run_detail.html
@@ -21,6 +21,18 @@
       <section>
         <h2>Metadata</h2>
         <dl class="meta">
+          <dt>Repository</dt>
+          <dd>{{ run.repo | default("-") }}</dd>
+          <dt>Pull Request</dt>
+          <dd>
+            {% if run.pr_url %}
+              <a href="{{ run.pr_url }}" target="_blank" rel="noreferrer">
+                #{{ run.pr_number }}
+              </a>
+            {% else %}
+              {{ run.pr_number | default("-") }}
+            {% endif %}
+          </dd>
           <dt>Status</dt>
           <dd>{{ run.status | default("pending") }}</dd>
           <dt>Created At</dt>


### PR DESCRIPTION
## Summary
- include repository and pull request metadata on the run detail page
- render a direct GitHub PR link for queued and completed runs
