### PR TITLE
feat: show run history on homepage

### DIFF
--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -49,12 +49,27 @@ def _fetch_runs(limit: int = 20) -> list[dict[str, str]]:
             "id": str(row["id"]),
             "repo": str(row["repo"]),
             "pr_number": str(row["pr_number"]),
+            "pr_url": f"https://github.com/{row['repo']}/pull/{row['pr_number']}",
             "status": str(row["status"]),
+            "status_class": _status_class(str(row["status"])),
             "created_at": str(row["created_at"]),
             "updated_at": str(row["updated_at"]),
         }
         for row in rows
     ]
+
+
+def _status_class(status: str) -> str:
+    normalized = status.strip().lower()
+    if normalized in {"success", "completed"}:
+        return "success"
+    if normalized in {"failed", "cancelled"}:
+        return "failed"
+    if normalized in {"running"}:
+        return "running"
+    if normalized in {"retry_scheduled"}:
+        return "retry"
+    return "queued"
 
 
 def _read_log_preview(logs_path: str | None, max_chars: int = 1200) -> str:

--- a/app/static/app.css
+++ b/app/static/app.css
@@ -195,3 +195,65 @@ button:hover {
   margin-top: 0.2rem;
   font-size: 0.86rem;
 }
+
+.run-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.run-card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.9rem 1rem;
+  background: #fbfcfe;
+}
+
+.run-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.8rem;
+}
+
+.run-meta {
+  grid-template-columns: 100px 1fr;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.84rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.status-pill.queued {
+  color: #6b5200;
+  background: #fff3c4;
+}
+
+.status-pill.running {
+  color: #0b4f85;
+  background: #dcefff;
+}
+
+.status-pill.success {
+  color: #0f5132;
+  background: #dff5e7;
+}
+
+.status-pill.failed {
+  color: #842029;
+  background: #f8d7da;
+}
+
+.status-pill.retry {
+  color: #5f3a8d;
+  background: #ece2ff;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,23 +10,42 @@
     <main class="container">
       <header>
         <h1>Runs</h1>
-        <p class="muted">Minimal server-rendered dashboard placeholder.</p>
+        <p class="muted">Recent and historical autofix runs.</p>
         <p><a href="/issues">Submit issue</a> · <a href="/settings">Settings</a></p>
       </header>
 
       <section>
-        <h2>Task List</h2>
+        <h2>Run History</h2>
         {% if runs and runs|length > 0 %}
-        <ul class="list">
+        <ul class="run-list">
           {% for run in runs %}
-          <li>
-            <a href="/runs/{{ run.id }}">{{ run.id }}</a>
-            <span class="muted">{{ run.status | default("pending") }}</span>
+          <li class="run-card">
+            <div class="run-card-head">
+              <div>
+                <a href="/runs/{{ run.id }}">Run #{{ run.id }}</a>
+                <div class="tiny muted">{{ run.repo }}</div>
+              </div>
+              <span class="status-pill {{ run.status_class }}">
+                {{ run.status | default("pending") }}
+              </span>
+            </div>
+            <dl class="meta run-meta">
+              <dt>Pull Request</dt>
+              <dd>
+                <a href="{{ run.pr_url }}" target="_blank" rel="noreferrer">
+                  #{{ run.pr_number }}
+                </a>
+              </dd>
+              <dt>Created</dt>
+              <dd>{{ run.created_at }}</dd>
+              <dt>Updated</dt>
+              <dd>{{ run.updated_at }}</dd>
+            </dl>
           </li>
           {% endfor %}
         </ul>
         {% else %}
-        <p class="empty">No runs yet. This is a placeholder for M1.</p>
+        <p class="empty">No runs yet.</p>
         {% endif %}
       </section>
     </main>


### PR DESCRIPTION
## Summary
- render historical runs on the homepage instead of a placeholder list
- add direct PR links and timestamps for each run
- use different colors for different run statuses
