### PR TITLE
feat: add stop action for active runs

### DIFF
--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -26,7 +26,7 @@ from app.services.policy import (
     get_remaining_autofix_quota,
     reset_autofix_count_on_sha_change,
 )
-from app.services.queue import enqueue_autofix_run
+from app.services.queue import enqueue_autofix_run, request_run_cancel
 
 
 router = APIRouter(tags=["web"])
@@ -65,7 +65,7 @@ def _status_class(status: str) -> str:
         return "success"
     if normalized in {"failed", "cancelled"}:
         return "failed"
-    if normalized in {"running"}:
+    if normalized in {"running", "cancel_requested"}:
         return "running"
     if normalized in {"retry_scheduled"}:
         return "retry"
@@ -398,6 +398,27 @@ async def api_run_detail(run_id: str) -> JSONResponse:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="run_id must be an integer",
+        )
+    return JSONResponse(_load_run_detail(run_id_value))
+
+
+@router.post("/api/runs/{run_id}/cancel")
+async def api_cancel_run(run_id: str) -> JSONResponse:
+    try:
+        run_id_value = int(run_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="run_id must be an integer",
+        )
+
+    with connect_db() as conn:
+        cancelled_status = request_run_cancel(conn, run_id_value)
+
+    if cancelled_status is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="run not found",
         )
     return JSONResponse(_load_run_detail(run_id_value))
 

--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -12,6 +12,7 @@ import signal
 import subprocess
 import tempfile
 import threading
+import time
 from typing import Any, Callable, Mapping
 
 from app.config import get_settings
@@ -30,7 +31,7 @@ from app.services.git_ops import (
 from app.services.logging_config import cleanup_archived_logs, get_run_log_path
 from app.services.feature_flags import resolve_agent_feature_flags
 from app.services.policy import increment_autofix_count
-from app.services.queue import mark_run_finished
+from app.services.queue import get_run_status, is_run_cancel_requested, mark_run_finished
 from app.services.retry import RetryConfig, schedule_retry
 
 
@@ -43,6 +44,7 @@ CLAUDE_AGENT_MODE = "claude_agent_sdk"
 OPENHANDS_FAILURE_CODE_WORKTREE = "agent_worktree_failed"
 OPENHANDS_FAILURE_CODE_COMMAND = "agent_openhands_failed"
 CLAUDE_FAILURE_CODE_COMMAND = "agent_claude_failed"
+RUN_CANCELLED_CODE = "cancelled"
 
 _REDACTION_PATTERNS = (
     re.compile(r"(ghp_[A-Za-z0-9]{16,})"),
@@ -273,6 +275,24 @@ def run_once(
             "comment_posted": False,
         }
 
+    if is_run_cancel_requested(conn, run_id):
+        logger.append("cancel_requested: stopping run before execution")
+        logs_path = logger.flush()
+        status, run_error_summary = _finish_cancelled_run(
+            conn,
+            run_id,
+            logs_path,
+        )
+        return {
+            "run_id": run_id,
+            "status": status,
+            "error_summary": run_error_summary,
+            "logs_path": logs_path,
+            "commit_sha": None,
+            "checks": checks_summary,
+            "comment_posted": False,
+        }
+
     agent_workspace = workspace
     agent_worktree: str | None = None
     if OPENHANDS_AGENT_MODE in agent_modes or CLAUDE_AGENT_MODE in agent_modes:
@@ -340,6 +360,7 @@ def run_once(
                 feature_flags.claude_agent_command_timeout_seconds
             ),
             on_log_line=logger.append,
+            should_cancel=lambda: is_run_cancel_requested(conn, run_id),
         )
         if used_agent_mode in {OPENHANDS_AGENT_MODE, CLAUDE_AGENT_MODE}:
             check_workspace = agent_workspace
@@ -348,6 +369,22 @@ def run_once(
             logger.append(f"agent_error: {sdk_error_message}")
 
         if not sdk_ok:
+            if sdk_error_code == RUN_CANCELLED_CODE:
+                logs_path = logger.flush()
+                status, run_error_summary = _finish_cancelled_run(
+                    conn,
+                    run_id,
+                    logs_path,
+                )
+                return {
+                    "run_id": run_id,
+                    "status": status,
+                    "error_summary": run_error_summary,
+                    "logs_path": logs_path,
+                    "commit_sha": None,
+                    "checks": checks_summary,
+                    "comment_posted": False,
+                }
             failure_summary = (
                 f"{sdk_error_code}: {sdk_error_message}"
                 if sdk_error_code and sdk_error_message
@@ -379,6 +416,23 @@ def run_once(
 
         if run_error_summary is None:
             for command in commands:
+                if is_run_cancel_requested(conn, run_id):
+                    logger.append("cancel_requested: stopping run before checks")
+                    logs_path = logger.flush()
+                    status, run_error_summary = _finish_cancelled_run(
+                        conn,
+                        run_id,
+                        logs_path,
+                    )
+                    return {
+                        "run_id": run_id,
+                        "status": status,
+                        "error_summary": run_error_summary,
+                        "logs_path": logs_path,
+                        "commit_sha": None,
+                        "checks": checks_summary,
+                        "comment_posted": False,
+                    }
                 result = _coerce_result(execute(command, check_workspace))
                 check_results.append(
                     {
@@ -566,6 +620,7 @@ def _execute_agent_sdks(
     claude_agent_command: str,
     claude_agent_command_timeout_seconds: int,
     on_log_line: Callable[[str], None] | None = None,
+    should_cancel: Callable[[], bool] | None = None,
 ) -> tuple[bool, str | None, str | None, str | None]:
     last_error_code: str | None = None
     last_error_message: str | None = None
@@ -580,6 +635,7 @@ def _execute_agent_sdks(
                 command=openhands_command,
                 timeout_seconds=openhands_command_timeout_seconds,
                 on_log_line=on_log_line,
+                should_cancel=should_cancel,
             )
             if openhands_ok:
                 return True, None, None, OPENHANDS_AGENT_MODE
@@ -598,6 +654,7 @@ def _execute_agent_sdks(
                 command=claude_agent_command,
                 timeout_seconds=claude_agent_command_timeout_seconds,
                 on_log_line=on_log_line,
+                should_cancel=should_cancel,
             )
             if claude_ok:
                 return True, None, None, CLAUDE_AGENT_MODE
@@ -619,6 +676,7 @@ def _run_openhands_agent(
     command: str,
     timeout_seconds: int,
     on_log_line: Callable[[str], None] | None = None,
+    should_cancel: Callable[[], bool] | None = None,
 ) -> tuple[bool, str, str | None]:
     return _run_agent_command(
         workspace=workspace,
@@ -631,6 +689,7 @@ def _run_openhands_agent(
         agent_name="OpenHands",
         failure_code=OPENHANDS_FAILURE_CODE_COMMAND,
         on_log_line=on_log_line,
+        should_cancel=should_cancel,
     )
 
 
@@ -644,6 +703,7 @@ def _run_claude_agent(
     command: str,
     timeout_seconds: int,
     on_log_line: Callable[[str], None] | None = None,
+    should_cancel: Callable[[], bool] | None = None,
 ) -> tuple[bool, str, str | None]:
     return _run_agent_command(
         workspace=workspace,
@@ -656,6 +716,7 @@ def _run_claude_agent(
         agent_name="Claude Agent SDK",
         failure_code=CLAUDE_FAILURE_CODE_COMMAND,
         on_log_line=on_log_line,
+        should_cancel=should_cancel,
     )
 
 
@@ -671,6 +732,7 @@ def _run_agent_command(
     agent_name: str,
     failure_code: str,
     on_log_line: Callable[[str], None] | None = None,
+    should_cancel: Callable[[], bool] | None = None,
 ) -> tuple[bool, str, str | None]:
     normalized_command = command.strip()
     if not normalized_command:
@@ -733,10 +795,19 @@ def _run_agent_command(
         if process.stdin is not None:
             process.stdin.write(prompt)
             process.stdin.close()
-        process.wait(timeout=timeout_seconds)
-    except subprocess.TimeoutExpired:
-        _terminate_agent_process_tree(process)
-        return False, f"{agent_name} command timed out after {timeout_seconds}s", failure_code
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            if should_cancel is not None and should_cancel():
+                if on_log_line is not None:
+                    on_log_line("[agent] cancellation requested; terminating process")
+                _terminate_agent_process_tree(process)
+                return False, f"{agent_name} command cancelled by user", RUN_CANCELLED_CODE
+            if process.poll() is not None:
+                break
+            if time.monotonic() >= deadline:
+                _terminate_agent_process_tree(process)
+                return False, f"{agent_name} command timed out after {timeout_seconds}s", failure_code
+            time.sleep(1.0)
     except OSError as exc:
         return False, f"{agent_name} command failed while running: {exc}", failure_code
     finally:
@@ -948,6 +1019,28 @@ def _append_logs(logs_path: str, lines: list[str]) -> None:
     with path.open("a", encoding="utf-8") as handle:
         handle.write(prefix)
         handle.write("\n".join(lines))
+
+
+def _finish_cancelled_run(
+    conn: sqlite3.Connection,
+    run_id: int,
+    logs_path: str,
+) -> tuple[str, str]:
+    current_status = get_run_status(conn, run_id) or "cancelled"
+    error_summary = (
+        "cancel_requested_by_user"
+        if current_status == "cancel_requested"
+        else "cancelled_by_user"
+    )
+    mark_run_finished(
+        conn=conn,
+        run_id=run_id,
+        status="cancelled",
+        error_summary=error_summary,
+        logs_path=logs_path,
+        last_error_code=RUN_CANCELLED_CODE,
+    )
+    return "cancelled", error_summary
 
 
 def _finish_failed_run(

--- a/app/services/concurrency.py
+++ b/app/services/concurrency.py
@@ -130,7 +130,11 @@ def get_pr_lock(conn: sqlite3.Connection, repo: str, pr_number: int) -> PRLock |
 
 def count_running_runs(conn: sqlite3.Connection) -> int:
     row = conn.execute(
-        "SELECT COUNT(*) AS count FROM autofix_runs WHERE status = 'running'"
+        """
+        SELECT COUNT(*) AS count
+        FROM autofix_runs
+        WHERE status IN ('running', 'cancel_requested')
+        """
     ).fetchone()
     if row is None:
         return 0

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -178,6 +178,61 @@ def mark_run_finished(
     conn.commit()
 
 
+def get_run_status(conn: sqlite3.Connection, run_id: int) -> str | None:
+    row = conn.execute(
+        "SELECT status FROM autofix_runs WHERE id = ?",
+        (run_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return str(row["status"])
+
+
+def is_run_cancel_requested(conn: sqlite3.Connection, run_id: int) -> bool:
+    return get_run_status(conn, run_id) == "cancel_requested"
+
+
+def request_run_cancel(conn: sqlite3.Connection, run_id: int) -> str | None:
+    current_status = get_run_status(conn, run_id)
+    if current_status is None:
+        return None
+
+    if current_status in {"success", "failed", "cancelled"}:
+        return current_status
+
+    if current_status in {"queued", "retry_scheduled"}:
+        conn.execute(
+            """
+            UPDATE autofix_runs
+            SET status = 'cancelled',
+                error_summary = 'cancelled_by_user',
+                last_error_code = 'cancelled',
+                last_error_at = CURRENT_TIMESTAMP,
+                finished_at = CURRENT_TIMESTAMP,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (run_id,),
+        )
+        conn.commit()
+        return "cancelled"
+
+    conn.execute(
+        """
+        UPDATE autofix_runs
+        SET status = 'cancel_requested',
+            error_summary = 'cancel_requested_by_user',
+            last_error_code = 'cancel_requested',
+            last_error_at = CURRENT_TIMESTAMP,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?
+        """,
+        (run_id,),
+    )
+    conn.commit()
+    return "cancel_requested"
+
+
 def _promote_due_retries(conn: sqlite3.Connection) -> None:
     """
     将到期的重试任务从 'retry_scheduled' 状态提升为 'queued' 状态。

--- a/app/static/app.css
+++ b/app/static/app.css
@@ -151,6 +151,12 @@ a:hover {
   border-color: #93c5fd;
 }
 
+.status-pill--cancel_requested {
+  color: #9a3412;
+  background: #ffedd5;
+  border-color: #fdba74;
+}
+
 .status-pill--success {
   color: #166534;
   background: #dcfce7;
@@ -161,6 +167,12 @@ a:hover {
   color: #991b1b;
   background: #fee2e2;
   border-color: #fca5a5;
+}
+
+.status-pill--cancelled {
+  color: #475569;
+  background: #e2e8f0;
+  border-color: #cbd5e1;
 }
 
 .status-pill--retry_scheduled {
@@ -199,6 +211,10 @@ a:hover {
   font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: 0.02em;
+}
+
+.run-action-button[hidden] {
+  display: none;
 }
 
 .log-live {
@@ -298,6 +314,19 @@ button {
 
 button:hover {
   filter: brightness(0.95);
+}
+
+button.button-danger {
+  background: #b91c1c;
+}
+
+button.button-danger:hover {
+  filter: brightness(0.92);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
 }
 
 .stacked-header {

--- a/app/templates/run_detail.html
+++ b/app/templates/run_detail.html
@@ -56,6 +56,9 @@
           </div>
           <div class="log-toolbar-meta">
             <span id="polling-indicator" class="live-indicator">Live</span>
+            <button id="stop-run-button" type="button" class="button-danger run-action-button" hidden>
+              Stop run
+            </button>
           </div>
         </div>
         <pre id="run-log" class="log log-live">{{ run.log_preview | default("No log data yet.") }}</pre>
@@ -77,13 +80,34 @@
         const updatedAt = document.getElementById("run-updated-at");
         const logNode = document.getElementById("run-log");
         const pollingIndicator = document.getElementById("polling-indicator");
-        const activeStatuses = new Set(["queued", "running"]);
+        const stopButton = document.getElementById("stop-run-button");
+        const activeStatuses = new Set(["queued", "running", "cancel_requested"]);
         let pollHandle = null;
 
         const setStatus = (status) => {
           statusPill.textContent = status;
           statusText.textContent = status;
           statusPill.className = `status-pill status-pill--${status}`;
+        };
+
+        const updateStopButton = (status) => {
+          if (!stopButton) {
+            return;
+          }
+          if (status === "cancel_requested") {
+            stopButton.hidden = false;
+            stopButton.disabled = true;
+            stopButton.textContent = "Stopping...";
+            return;
+          }
+          if (status === "queued" || status === "running") {
+            stopButton.hidden = false;
+            stopButton.disabled = false;
+            stopButton.textContent = "Stop run";
+            return;
+          }
+          stopButton.hidden = true;
+          stopButton.disabled = true;
         };
 
         const setPrUrl = (url, prNumber) => {
@@ -104,6 +128,7 @@
           repoText.textContent = run.repo || "-";
           setPrUrl(run.pr_url || "", run.pr_number || "");
           setStatus(run.status || "not_found");
+          updateStopButton(run.status || "not_found");
           createdAt.textContent = run.created_at || "-";
           updatedAt.textContent = run.updated_at || "-";
           logNode.textContent = run.log_preview || "No log data yet.";
@@ -115,6 +140,25 @@
             window.clearInterval(pollHandle);
             pollHandle = null;
           }
+        };
+
+        const cancelRun = async () => {
+          if (!stopButton) {
+            return;
+          }
+          stopButton.disabled = true;
+          stopButton.textContent = "Stopping...";
+          const response = await fetch(`/api/runs/${runId}/cancel`, {
+            method: "POST",
+            cache: "no-store"
+          });
+          if (!response.ok) {
+            stopButton.disabled = false;
+            stopButton.textContent = "Stop failed";
+            pollingIndicator.textContent = "Error";
+            return;
+          }
+          updateView(await response.json());
         };
 
         const fetchRun = async () => {
@@ -131,6 +175,9 @@
           pollHandle = window.setInterval(fetchRun, 2000);
         } else {
           pollingIndicator.textContent = "Final";
+        }
+        if (stopButton) {
+          stopButton.addEventListener("click", cancelRun);
         }
       })();
     </script>


### PR DESCRIPTION
## Summary
- add a stop button to the live run detail page
- let users cancel queued runs immediately and request cancellation for running runs
- make the worker terminate active agent processes after cancellation is requested
