### PR TITLE
feat: add delete action for completed runs

### DIFF
--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -423,6 +423,61 @@ async def api_cancel_run(run_id: str) -> JSONResponse:
     return JSONResponse(_load_run_detail(run_id_value))
 
 
+@router.delete("/api/runs/{run_id}")
+async def api_delete_run(run_id: str) -> JSONResponse:
+    try:
+        run_id_value = int(run_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="run_id must be an integer",
+        )
+
+    with connect_db() as conn:
+        row = conn.execute(
+            """
+            SELECT id, repo, pr_number, status
+            FROM autofix_runs
+            WHERE id = ?
+            """,
+            (run_id_value,),
+        ).fetchone()
+        if row is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="run not found",
+            )
+
+        run_status = str(row["status"])
+        if run_status in {"queued", "running", "cancel_requested", "retry_scheduled"}:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="active runs must be stopped before deletion",
+            )
+
+        repo = str(row["repo"])
+        pr_number = int(row["pr_number"])
+
+        conn.execute("DELETE FROM autofix_runs WHERE id = ?", (run_id_value,))
+        remaining = conn.execute(
+            """
+            SELECT 1
+            FROM autofix_runs
+            WHERE repo = ? AND pr_number = ?
+            LIMIT 1
+            """,
+            (repo, pr_number),
+        ).fetchone()
+        if remaining is None:
+            conn.execute(
+                "DELETE FROM pull_requests WHERE repo = ? AND pr_number = ?",
+                (repo, pr_number),
+            )
+        conn.commit()
+
+    return JSONResponse({"ok": True, "deleted_run_id": run_id_value})
+
+
 @router.get("/settings", response_class=HTMLResponse)
 async def settings_page(request: Request) -> HTMLResponse:
     templates: Jinja2Templates = request.app.state.templates

--- a/app/templates/run_detail.html
+++ b/app/templates/run_detail.html
@@ -59,6 +59,9 @@
             <button id="stop-run-button" type="button" class="button-danger run-action-button" hidden>
               Stop run
             </button>
+            <button id="delete-run-button" type="button" class="run-action-button" hidden>
+              Delete run
+            </button>
           </div>
         </div>
         <pre id="run-log" class="log log-live">{{ run.log_preview | default("No log data yet.") }}</pre>
@@ -81,6 +84,7 @@
         const logNode = document.getElementById("run-log");
         const pollingIndicator = document.getElementById("polling-indicator");
         const stopButton = document.getElementById("stop-run-button");
+        const deleteButton = document.getElementById("delete-run-button");
         const activeStatuses = new Set(["queued", "running", "cancel_requested"]);
         let pollHandle = null;
 
@@ -110,6 +114,25 @@
           stopButton.disabled = true;
         };
 
+        const updateDeleteButton = (status) => {
+          if (!deleteButton) {
+            return;
+          }
+          if (activeStatuses.has(status)) {
+            deleteButton.hidden = true;
+            deleteButton.disabled = true;
+            return;
+          }
+          if (status === "not_found") {
+            deleteButton.hidden = true;
+            deleteButton.disabled = true;
+            return;
+          }
+          deleteButton.hidden = false;
+          deleteButton.disabled = false;
+          deleteButton.textContent = "Delete run";
+        };
+
         const setPrUrl = (url, prNumber) => {
           if (!url) {
             prText.textContent = "-";
@@ -129,6 +152,7 @@
           setPrUrl(run.pr_url || "", run.pr_number || "");
           setStatus(run.status || "not_found");
           updateStopButton(run.status || "not_found");
+          updateDeleteButton(run.status || "not_found");
           createdAt.textContent = run.created_at || "-";
           updatedAt.textContent = run.updated_at || "-";
           logNode.textContent = run.log_preview || "No log data yet.";
@@ -140,6 +164,25 @@
             window.clearInterval(pollHandle);
             pollHandle = null;
           }
+        };
+
+        const deleteRun = async () => {
+          if (!deleteButton) {
+            return;
+          }
+          deleteButton.disabled = true;
+          deleteButton.textContent = "Deleting...";
+          const response = await fetch(`/api/runs/${runId}`, {
+            method: "DELETE",
+            cache: "no-store"
+          });
+          if (!response.ok) {
+            deleteButton.disabled = false;
+            deleteButton.textContent = "Delete failed";
+            pollingIndicator.textContent = "Error";
+            return;
+          }
+          window.location.href = "/";
         };
 
         const cancelRun = async () => {
@@ -178,6 +221,9 @@
         }
         if (stopButton) {
           stopButton.addEventListener("click", cancelRun);
+        }
+        if (deleteButton) {
+          deleteButton.addEventListener("click", deleteRun);
         }
       })();
     </script>


### PR DESCRIPTION
## Summary
- add a delete action to the run detail page
- only allow deleting completed runs to avoid hiding active background work
- prune pull request rows when their last run is deleted
