### PR TITLE
fix: fall back to cli check commands

### DIFF
--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -1508,7 +1508,8 @@ def _default_executor(
         fallback_python = sys.executable or shutil.which("python3")
         if fallback_python:
             argv[0] = fallback_python
-    return subprocess.run(
+
+    result = subprocess.run(
         argv,
         cwd=workspace_dir,
         check=False,
@@ -1516,6 +1517,25 @@ def _default_executor(
         text=True,
         timeout=CHECK_COMMAND_TIMEOUT_SECONDS,
     )
+    missing_module_match = re.search(r"No module named ([A-Za-z0-9_.-]+)", result.stderr or "")
+    if (
+        result.returncode != 0
+        and len(argv) >= 3
+        and argv[1] == "-m"
+        and missing_module_match is not None
+    ):
+        cli_name = missing_module_match.group(1)
+        cli_path = shutil.which(cli_name)
+        if cli_path:
+            return subprocess.run(
+                [cli_name, *argv[3:]],
+                cwd=workspace_dir,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=CHECK_COMMAND_TIMEOUT_SECONDS,
+            )
+    return result
 
 
 def _coerce_result(result: Any) -> dict[str, Any]:

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+import sys
 from pathlib import Path
 
 import pytest
@@ -249,6 +250,41 @@ def test_run_once_fails_for_unknown_project_type(tmp_path: Path) -> None:
     assert result["status"] == "failed"
     assert "unsupported_project_type" in str(result["error_summary"])
     assert result["comment_posted"] is False
+
+
+def test_default_executor_falls_back_to_cli_when_python_module_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    class _Result:
+        def __init__(self, returncode: int, stdout: str, stderr: str) -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def fake_run(command, **kwargs):
+        calls.append(list(command))
+        if command[:3] == [sys.executable, "-m", "ruff"]:
+            return _Result(1, "", f"{sys.executable}: No module named ruff")
+        if command[:1] == ["ruff"]:
+            return _Result(0, "lint ok", "")
+        return _Result(0, "ok", "")
+
+    import subprocess
+
+    monkeypatch.setattr(shutil, "which", lambda value: None if value == "python" else f"/usr/bin/{value}")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = _default_executor("python -m ruff check .", str(tmp_path))
+
+    assert calls == [
+        [sys.executable, "-m", "ruff", "check", "."],
+        ["ruff", "check", "."],
+    ]
+    assert result.returncode == 0
+    assert result.stdout == "lint ok"
 
 
 def test_run_once_schedules_retry_for_git_failure(


### PR DESCRIPTION
## Summary
- fall back from `python -m <tool>` to the matching CLI when the module is unavailable
- keep the existing check command templates unchanged
- cover the fallback with a targeted agent runner test