### PR TITLE
fix: accept bot review webhooks

### DIFF
--- a/app/routes/github.py
+++ b/app/routes/github.py
@@ -32,6 +32,10 @@ from app.services.github_signature import (
 
 
 router = APIRouter(prefix="/github", tags=["github"])
+_REVIEW_EVENTS_ALLOWING_BOT_ACTORS = {
+    "pull_request_review",
+    "pull_request_review_comment",
+}
 
 
 async def _read_payload(request: Request) -> dict[str, Any]:
@@ -86,6 +90,7 @@ async def github_webhook(request: Request) -> dict[str, Any]:
         event.repo,
         actor=event.actor,
         body=extract_event_body(event_type, payload),
+        bot_logins=() if event_type in _REVIEW_EVENTS_ALLOWING_BOT_ACTORS else None,
     )
     if filter_reason is not None:
         return {

--- a/tests/test_github_webhook_route.py
+++ b/tests/test_github_webhook_route.py
@@ -139,6 +139,30 @@ def test_bot_comment_is_filtered(tmp_path: Path) -> None:
     assert response.json()["reason"] == "noise_actor"
 
 
+def test_bot_pull_request_review_is_queued(tmp_path: Path) -> None:
+    _set_env(tmp_path, secret="")
+
+    payload = {
+        "repository": {"full_name": "acme/widgets"},
+        "pull_request": {"number": 42, "head": {"sha": "abc123"}},
+        "review": {"id": 1003, "body": "Please fix this"},
+        "sender": {"login": "github-actions[bot]"},
+    }
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/github/webhook",
+            json=payload,
+            headers={"X-GitHub-Event": "pull_request_review"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["ignored"] is not True
+    assert response.json()["insert_status"] == "inserted"
+    assert response.json()["queue_status"] == "queued"
+    assert isinstance(response.json()["queued_run_id"], int)
+
+
 def test_autofix_limit_prevents_queueing_new_run(tmp_path: Path) -> None:
     _set_env(tmp_path, secret="")
     db_path = tmp_path / "software_factory.db"


### PR DESCRIPTION
## Summary
- allow bot-authored pull request review events to enter the webhook queue
- keep bot issue comments filtered to avoid loops
- add a webhook route regression test for bot review events