### PR TITLE
feat: allow bash in claude agent runs

### DIFF
--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -989,6 +989,18 @@ def _build_claude_stream_command_argv(argv: list[str]) -> list[str]:
         expanded.append("--print")
     if "--verbose" not in expanded:
         expanded.append("--verbose")
+    if "--permission-mode" not in expanded:
+        expanded.extend(["--permission-mode", "auto"])
+    if not any(
+        token == "--allowed-tools" or token.startswith("--allowed-tools=")
+        for token in expanded
+    ):
+        expanded.extend(
+            [
+                "--allowed-tools",
+                "Bash,Read,Edit,Glob,Grep,LS,WebFetch",
+            ]
+        )
     if not any(
         token == "--output-format" or token.startswith("--output-format=")
         for token in expanded

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -750,6 +750,10 @@ def test_run_claude_agent_uses_normalized_command_and_filtered_env(
         "claude",
         "--print",
         "--verbose",
+        "--permission-mode",
+        "auto",
+        "--allowed-tools",
+        "Bash,Read,Edit,Glob,Grep,LS,WebFetch",
         "--output-format",
         "stream-json",
     ]


### PR DESCRIPTION
## Summary
- run Claude agent in non-interactive auto permission mode
- allow Bash and related read/edit tools by default for worker-driven Claude runs
- keep the stream-json execution path and update the command argv test

## Testing
- pytest -q