### PR TITLE
feat: add claude docker runtime

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -49,6 +49,8 @@ class Settings(BaseSettings):
     agent_sdks: tuple[str, ...] = ("claude_agent_sdk", "openhands")
     openhands_command: str = "openhands"
     claude_agent_sdk_command: str = "claude"
+    claude_agent_sdk_runtime: str = "host"
+    claude_agent_sdk_container_image: str = ""
     openhands_command_timeout_seconds: int = 600
     claude_agent_sdk_command_timeout_seconds: int = 600
     openhands_worktree_base_dir: str = ".software-factory-worktrees"

--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -503,6 +503,10 @@ async def save_settings(request: Request) -> RedirectResponse:
 
     openhands_command = str(form.get("openhands_command", "openhands")).strip()
     claude_agent_command = str(form.get("claude_agent_command", "claude")).strip()
+    claude_agent_runtime = str(form.get("claude_agent_runtime", "host")).strip()
+    claude_agent_container_image = str(
+        form.get("claude_agent_container_image", "")
+    ).strip()
     openhands_worktree_base_dir = str(
         form.get("openhands_worktree_base_dir", ".software-factory-worktrees")
     ).strip()
@@ -531,6 +535,8 @@ async def save_settings(request: Request) -> RedirectResponse:
             openhands_command_timeout_seconds=openhands_command_timeout_seconds,
             openhands_worktree_base_dir=openhands_worktree_base_dir,
             claude_agent_command=claude_agent_command,
+            claude_agent_runtime=claude_agent_runtime,
+            claude_agent_container_image=claude_agent_container_image,
             claude_agent_command_timeout_seconds=(
                 claude_agent_command_timeout_seconds
             ),

--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -396,6 +396,10 @@ def run_once(
                     feature_flags.openhands_command_timeout_seconds
                 ),
                 claude_agent_command=feature_flags.claude_agent_command,
+                claude_agent_runtime=feature_flags.claude_agent_runtime,
+                claude_agent_container_image=(
+                    feature_flags.claude_agent_container_image
+                ),
                 claude_agent_command_timeout_seconds=(
                     feature_flags.claude_agent_command_timeout_seconds
                 ),
@@ -742,6 +746,8 @@ def _execute_agent_sdks(
     openhands_command: str,
     openhands_command_timeout_seconds: int,
     claude_agent_command: str,
+    claude_agent_runtime: str,
+    claude_agent_container_image: str,
     claude_agent_command_timeout_seconds: int,
     on_log_line: Callable[[str], None] | None = None,
     should_cancel: Callable[[], bool] | None = None,
@@ -781,6 +787,8 @@ def _execute_agent_sdks(
                 "pr_number": pr_number,
                 "prompt": prompt,
                 "command": claude_agent_command,
+                "runtime": claude_agent_runtime,
+                "container_image": claude_agent_container_image,
                 "timeout_seconds": claude_agent_command_timeout_seconds,
             }
             if on_log_line is not None:
@@ -835,10 +843,27 @@ def _run_claude_agent(
     prompt: str,
     *,
     command: str,
+    runtime: str,
+    container_image: str,
     timeout_seconds: int,
     on_log_line: Callable[[str], None] | None = None,
     should_cancel: Callable[[], bool] | None = None,
 ) -> tuple[bool, str, str | None]:
+    if runtime == "docker":
+        return _run_claude_container_command(
+            workspace=workspace,
+            run_id=run_id,
+            repo=repo,
+            pr_number=pr_number,
+            prompt=prompt,
+            command=command,
+            container_image=container_image,
+            timeout_seconds=timeout_seconds,
+            agent_name="Claude Agent SDK",
+            failure_code=CLAUDE_FAILURE_CODE_COMMAND,
+            on_log_line=on_log_line,
+            should_cancel=should_cancel,
+        )
     return _run_claude_stream_command(
         workspace=workspace,
         run_id=run_id,
@@ -849,6 +874,60 @@ def _run_claude_agent(
         timeout_seconds=timeout_seconds,
         agent_name="Claude Agent SDK",
         failure_code=CLAUDE_FAILURE_CODE_COMMAND,
+        on_log_line=on_log_line,
+        should_cancel=should_cancel,
+    )
+
+
+def _run_claude_container_command(
+    *,
+    workspace: str,
+    run_id: int,
+    repo: str,
+    pr_number: int,
+    prompt: str,
+    command: str,
+    container_image: str,
+    timeout_seconds: int,
+    agent_name: str,
+    failure_code: str,
+    on_log_line: Callable[[str], None] | None = None,
+    should_cancel: Callable[[], bool] | None = None,
+) -> tuple[bool, str, str | None]:
+    normalized_command = command.strip()
+    if not normalized_command:
+        return False, f"{agent_name} command is not configured", failure_code
+    if not container_image.strip():
+        return False, f"{agent_name} container image is not configured", failure_code
+
+    try:
+        inner_argv = shlex.split(normalized_command)
+    except ValueError as exc:
+        return False, f"{agent_name} command is invalid: {exc}", failure_code
+    if not inner_argv:
+        return False, f"{agent_name} command is not configured", failure_code
+    if any(token in _DISALLOWED_COMMAND_TOKENS for token in inner_argv[1:]):
+        return (
+            False,
+            f"{agent_name} command contains unsupported shell control operators",
+            failure_code,
+        )
+    if not _command_exists("docker"):
+        return False, f"{agent_name} container runtime not found: docker", failure_code
+
+    argv = _build_claude_container_command_argv(
+        workspace=workspace,
+        container_image=container_image,
+        inner_argv=inner_argv,
+        container_env=_build_agent_environment(repo=repo, pr_number=pr_number, run_id=run_id),
+    )
+    return _run_claude_stream_subprocess(
+        workspace=workspace,
+        prompt=prompt,
+        argv=argv,
+        timeout_seconds=timeout_seconds,
+        agent_name=agent_name,
+        failure_code=failure_code,
         on_log_line=on_log_line,
         should_cancel=should_cancel,
     )
@@ -888,6 +967,31 @@ def _run_claude_stream_command(
         return False, f"{agent_name} command not found: {argv[0]}", failure_code
 
     argv = _build_claude_stream_command_argv(argv)
+    return _run_claude_stream_subprocess(
+        workspace=workspace,
+        prompt=prompt,
+        argv=argv,
+        timeout_seconds=timeout_seconds,
+        agent_name=agent_name,
+        failure_code=failure_code,
+        on_log_line=on_log_line,
+        should_cancel=should_cancel,
+        process_env=_build_agent_environment(repo=repo, pr_number=pr_number, run_id=run_id),
+    )
+
+
+def _run_claude_stream_subprocess(
+    *,
+    workspace: str,
+    prompt: str,
+    argv: list[str],
+    timeout_seconds: int,
+    agent_name: str,
+    failure_code: str,
+    on_log_line: Callable[[str], None] | None = None,
+    should_cancel: Callable[[], bool] | None = None,
+    process_env: dict[str, str] | None = None,
+) -> tuple[bool, str, str | None]:
 
     process: subprocess.Popen[str]
     try:
@@ -898,7 +1002,7 @@ def _run_claude_stream_command(
             stderr=subprocess.PIPE,
             stdin=subprocess.PIPE,
             text=True,
-            env=_build_agent_environment(repo=repo, pr_number=pr_number, run_id=run_id),
+            env=process_env,
             start_new_session=True,
         )
     except FileNotFoundError:
@@ -981,6 +1085,34 @@ def _run_claude_stream_command(
     if on_log_line is not None and state.get("saw_events"):
         on_log_line("[agent] completed")
     return True, result_text or f"{agent_name} completed", None
+
+
+def _build_claude_container_command_argv(
+    *,
+    workspace: str,
+    container_image: str,
+    inner_argv: list[str],
+    container_env: Mapping[str, str],
+) -> list[str]:
+    container_workspace = "/workspace"
+    expanded_inner = _build_claude_stream_command_argv(inner_argv)
+    argv = [
+        "docker",
+        "run",
+        "--rm",
+        "-i",
+        "--workdir",
+        container_workspace,
+        "--volume",
+        f"{Path(workspace).resolve()}:{container_workspace}",
+    ]
+    if hasattr(os, "getuid") and hasattr(os, "getgid"):
+        argv.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+    for key, value in sorted(container_env.items()):
+        argv.extend(["-e", f"{key}={value}"])
+    argv.append(container_image.strip())
+    argv.extend(expanded_inner)
+    return argv
 
 
 def _build_claude_stream_command_argv(argv: list[str]) -> list[str]:

--- a/app/services/feature_flags.py
+++ b/app/services/feature_flags.py
@@ -12,6 +12,8 @@ FEATURE_FLAG_OPENHANDS_TIMEOUT_KEY = "agent.openhands.command_timeout_seconds"
 FEATURE_FLAG_OPENHANDS_WORKTREE_DIR_KEY = "agent.openhands.worktree_base_dir"
 FEATURE_FLAG_CLAUDE_AGENT_ENABLED_KEY = "agent.claude_agent.enabled"
 FEATURE_FLAG_CLAUDE_AGENT_COMMAND_KEY = "agent.claude_agent.command"
+FEATURE_FLAG_CLAUDE_AGENT_RUNTIME_KEY = "agent.claude_agent.runtime"
+FEATURE_FLAG_CLAUDE_AGENT_CONTAINER_IMAGE_KEY = "agent.claude_agent.container_image"
 FEATURE_FLAG_CLAUDE_AGENT_TIMEOUT_KEY = "agent.claude_agent.command_timeout_seconds"
 FEATURE_FLAG_CLAUDE_AGENT_WORKTREE_DIR_KEY = "agent.claude_agent.worktree_base_dir"
 FEATURE_FLAG_LEGACY_ENABLED_KEY = "agent.legacy.enabled"
@@ -19,6 +21,8 @@ FEATURE_FLAG_LEGACY_ENABLED_KEY = "agent.legacy.enabled"
 OPENHANDS_AGENT_MODE = "openhands"
 CLAUDE_AGENT_MODE = "claude_agent_sdk"
 LEGACY_AGENT_MODE = "legacy"
+CLAUDE_AGENT_RUNTIME_HOST = "host"
+CLAUDE_AGENT_RUNTIME_DOCKER = "docker"
 
 
 @dataclass(frozen=True)
@@ -28,6 +32,8 @@ class AgentFeatureFlags:
     openhands_command_timeout_seconds: int
     openhands_worktree_base_dir: str
     claude_agent_command: str
+    claude_agent_runtime: str
+    claude_agent_container_image: str
     claude_agent_command_timeout_seconds: int
     claude_agent_worktree_base_dir: str
 
@@ -53,6 +59,8 @@ def get_default_agent_feature_flags() -> AgentFeatureFlags:
         ),
         openhands_command=settings.openhands_command.strip() or "openhands",
         claude_agent_command=settings.claude_agent_sdk_command.strip() or "claude",
+        claude_agent_runtime=_normalize_runtime(settings.claude_agent_sdk_runtime),
+        claude_agent_container_image=settings.claude_agent_sdk_container_image.strip(),
         openhands_command_timeout_seconds=settings.openhands_command_timeout_seconds,
         openhands_worktree_base_dir=
         settings.openhands_worktree_base_dir.strip() or ".software-factory-worktrees",
@@ -118,6 +126,13 @@ def resolve_agent_feature_flags(
         FEATURE_FLAG_CLAUDE_AGENT_COMMAND_KEY,
         settings.claude_agent_command,
     ).strip() or settings.claude_agent_command
+    claude_runtime = _normalize_runtime(
+        raw_flags.get(FEATURE_FLAG_CLAUDE_AGENT_RUNTIME_KEY, settings.claude_agent_runtime)
+    )
+    claude_container_image = raw_flags.get(
+        FEATURE_FLAG_CLAUDE_AGENT_CONTAINER_IMAGE_KEY,
+        settings.claude_agent_container_image,
+    ).strip()
     claude_timeout = _coerce_int(
         raw_flags.get(FEATURE_FLAG_CLAUDE_AGENT_TIMEOUT_KEY),
         settings.claude_agent_command_timeout_seconds,
@@ -135,6 +150,8 @@ def resolve_agent_feature_flags(
         openhands_command_timeout_seconds=openhands_timeout,
         openhands_worktree_base_dir=worktree_dir,
         claude_agent_command=claude_command,
+        claude_agent_runtime=claude_runtime,
+        claude_agent_container_image=claude_container_image,
         claude_agent_command_timeout_seconds=claude_timeout,
         claude_agent_worktree_base_dir=claude_worktree_dir,
     )
@@ -149,6 +166,8 @@ def save_agent_feature_flags(
     openhands_command_timeout_seconds: int,
     openhands_worktree_base_dir: str,
     claude_agent_command: str,
+    claude_agent_runtime: str,
+    claude_agent_container_image: str,
     claude_agent_command_timeout_seconds: int,
     claude_agent_worktree_base_dir: str,
     legacy_enabled: bool | None = None,
@@ -166,6 +185,14 @@ def save_agent_feature_flags(
             openhands_worktree_base_dir.strip() or ".software-factory-worktrees",
         ),
         (FEATURE_FLAG_CLAUDE_AGENT_COMMAND_KEY, claude_agent_command.strip()),
+        (
+            FEATURE_FLAG_CLAUDE_AGENT_RUNTIME_KEY,
+            _normalize_runtime(claude_agent_runtime),
+        ),
+        (
+            FEATURE_FLAG_CLAUDE_AGENT_CONTAINER_IMAGE_KEY,
+            claude_agent_container_image.strip(),
+        ),
         (
             FEATURE_FLAG_CLAUDE_AGENT_TIMEOUT_KEY,
             str(max(1, int(claude_agent_command_timeout_seconds))),
@@ -203,6 +230,8 @@ def build_feature_flag_context(conn: sqlite3.Connection) -> Mapping[str, Any]:
         "openhands_command_timeout_seconds": str(flags.openhands_command_timeout_seconds),
         "openhands_worktree_base_dir": flags.openhands_worktree_base_dir,
         "claude_agent_command": flags.claude_agent_command,
+        "claude_agent_runtime": flags.claude_agent_runtime,
+        "claude_agent_container_image": flags.claude_agent_container_image,
         "claude_agent_command_timeout_seconds": str(
             flags.claude_agent_command_timeout_seconds
         ),
@@ -264,3 +293,10 @@ def _coerce_int(value: str | None, default: int) -> int:
         return int(str(value).strip())
     except (TypeError, ValueError):
         return default
+
+
+def _normalize_runtime(value: str | None) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized == CLAUDE_AGENT_RUNTIME_DOCKER:
+        return CLAUDE_AGENT_RUNTIME_DOCKER
+    return CLAUDE_AGENT_RUNTIME_HOST

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -81,6 +81,23 @@
               autocomplete="off"
             >
 
+            <label for="claude_agent_runtime">Claude Agent runtime</label>
+            <select id="claude_agent_runtime" name="claude_agent_runtime">
+              <option value="host" {% if claude_agent_runtime == "host" %}selected{% endif %}>Host</option>
+              <option value="docker" {% if claude_agent_runtime == "docker" %}selected{% endif %}>Docker</option>
+            </select>
+            <p class="muted tiny">Use Docker to isolate Claude execution from the host worker environment.</p>
+
+            <label for="claude_agent_container_image">Claude Agent container image</label>
+            <input
+              type="text"
+              id="claude_agent_container_image"
+              name="claude_agent_container_image"
+              value="{{ claude_agent_container_image }}"
+              autocomplete="off"
+            >
+            <p class="muted tiny">Required only when Claude Agent runtime is set to Docker.</p>
+
             <label for="claude_agent_command_timeout_seconds">Claude Agent command timeout (seconds)</label>
             <input
               type="number"

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -669,6 +669,8 @@ def test_execute_agent_sdks_falls_back_to_claude(monkeypatch: pytest.MonkeyPatch
         prompt: str,
         *,
         command: str,
+        runtime: str,
+        container_image: str,
         timeout_seconds: int,
         on_log_line: object | None = None,
         should_cancel: object | None = None,
@@ -689,6 +691,8 @@ def test_execute_agent_sdks_falls_back_to_claude(monkeypatch: pytest.MonkeyPatch
         openhands_command="openhands",
         openhands_command_timeout_seconds=600,
         claude_agent_command="claude",
+        claude_agent_runtime="host",
+        claude_agent_container_image="",
         claude_agent_command_timeout_seconds=600,
     )
     assert ok is True
@@ -740,6 +744,8 @@ def test_run_claude_agent_uses_normalized_command_and_filtered_env(
         pr_number=7,
         prompt="fix this",
         command="  claude --print  ",
+        runtime="host",
+        container_image="",
         timeout_seconds=42,
     )
 
@@ -773,6 +779,70 @@ def test_run_claude_agent_uses_normalized_command_and_filtered_env(
     assert "UNRELATED_SECRET" not in env
 
 
+def test_run_claude_agent_supports_docker_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeProcess:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.returncode = 0
+            self.pid = 1001
+            captured["command"] = list(args[0]) if args else []
+            captured.update(kwargs)
+
+        def communicate(
+            self,
+            input: str | None = None,
+            timeout: int | float | None = None,
+        ) -> tuple[str, str]:
+            captured["input"] = input
+            captured["timeout"] = timeout
+            return "done", ""
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+    monkeypatch.setattr(agent_runner.subprocess, "Popen", _FakeProcess)
+    monkeypatch.setattr(
+        agent_runner.shutil,
+        "which",
+        lambda value: "/usr/bin/docker" if value == "docker" else f"/usr/bin/{value}",
+    )
+
+    ok, message, error_code = _run_claude_agent(
+        workspace=str(tmp_path),
+        run_id=9,
+        repo="acme/widgets",
+        pr_number=7,
+        prompt="fix this",
+        command="claude",
+        runtime="docker",
+        container_image="ghcr.io/example/claude-code:latest",
+        timeout_seconds=42,
+    )
+
+    assert ok is True
+    assert message == "done"
+    assert error_code is None
+    assert captured["command"][:8] == [
+        "docker",
+        "run",
+        "--rm",
+        "-i",
+        "--workdir",
+        "/workspace",
+        "--volume",
+        f"{tmp_path.resolve()}:/workspace",
+    ]
+    assert "ghcr.io/example/claude-code:latest" in captured["command"]
+    assert "--allowed-tools" in captured["command"]
+    assert captured["cwd"] == str(tmp_path)
+    assert captured["input"] == "fix this"
+
+
 def test_run_claude_agent_rejects_shell_control_tokens(tmp_path: Path) -> None:
     ok, message, error_code = _run_claude_agent(
         workspace=str(tmp_path),
@@ -781,6 +851,8 @@ def test_run_claude_agent_rejects_shell_control_tokens(tmp_path: Path) -> None:
         pr_number=7,
         prompt="fix this",
         command="claude && whoami",
+        runtime="host",
+        container_image="",
         timeout_seconds=42,
     )
 

--- a/tests/test_web_settings.py
+++ b/tests/test_web_settings.py
@@ -31,6 +31,7 @@ def test_settings_page_loads_defaults(tmp_path: Path) -> None:
     assert "System Settings" in html
     assert "Enable OpenHands agent mode" in html
     assert "Enable Claude Agent SDK mode" in html
+    assert "Claude Agent runtime" in html
 
 
 def test_save_settings_updates_feature_flags(tmp_path: Path) -> None:
@@ -46,6 +47,8 @@ def test_save_settings_updates_feature_flags(tmp_path: Path) -> None:
                 "openhands_command_timeout_seconds": "123",
                 "openhands_worktree_base_dir": "tmp/worktrees",
                 "claude_agent_command": "claude-test",
+                "claude_agent_runtime": "docker",
+                "claude_agent_container_image": "ghcr.io/example/claude-code:latest",
                 "claude_agent_command_timeout_seconds": "222",
                 "claude_agent_worktree_base_dir": "tmp/claude-worktrees",
             },
@@ -67,6 +70,8 @@ def test_save_settings_updates_feature_flags(tmp_path: Path) -> None:
     assert flags["agent.openhands.enabled"] == "1"
     assert flags["agent.claude_agent.enabled"] == "1"
     assert flags["agent.claude_agent.command"] == "claude-test"
+    assert flags["agent.claude_agent.runtime"] == "docker"
+    assert flags["agent.claude_agent.container_image"] == "ghcr.io/example/claude-code:latest"
     assert flags["agent.claude_agent.command_timeout_seconds"] == "222"
     assert flags["agent.claude_agent.worktree_base_dir"] == "tmp/claude-worktrees"
     assert flags["agent.openhands.command"] == "openhands-test"
@@ -82,6 +87,8 @@ def test_save_settings_updates_feature_flags(tmp_path: Path) -> None:
     assert active_flags.openhands_command_timeout_seconds == 123
     assert active_flags.openhands_worktree_base_dir == "tmp/worktrees"
     assert active_flags.claude_agent_command == "claude-test"
+    assert active_flags.claude_agent_runtime == "docker"
+    assert active_flags.claude_agent_container_image == "ghcr.io/example/claude-code:latest"
     assert active_flags.claude_agent_command_timeout_seconds == 222
     assert active_flags.claude_agent_worktree_base_dir == "tmp/claude-worktrees"
     assert "openhands" in active_flags.agent_sdks


### PR DESCRIPTION
## Summary
- add a Docker runtime option for Claude agent execution
- expose Claude runtime and container image in settings/feature flags
- keep the existing host runtime as the default path

## Testing
- pytest -q