### PR TITLE
feat: add claude agent docker image

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -50,7 +50,7 @@ class Settings(BaseSettings):
     openhands_command: str = "openhands"
     claude_agent_sdk_command: str = "claude"
     claude_agent_sdk_runtime: str = "host"
-    claude_agent_sdk_container_image: str = ""
+    claude_agent_sdk_container_image: str = "software-factory/claude-agent:latest"
     openhands_command_timeout_seconds: int = 600
     claude_agent_sdk_command_timeout_seconds: int = 600
     openhands_worktree_base_dir: str = ".software-factory-worktrees"

--- a/docker/claude-agent/Dockerfile
+++ b/docker/claude-agent/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:22-bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        openssh-client \
+        python3 \
+        python3-pip \
+        python3-venv \
+        ripgrep \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @anthropic-ai/claude-code
+
+RUN python3 -m pip install --break-system-packages --no-cache-dir \
+    pip \
+    pytest \
+    ruff \
+    mypy
+
+WORKDIR /workspace
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["claude"]

--- a/tests/test_web_settings.py
+++ b/tests/test_web_settings.py
@@ -32,6 +32,7 @@ def test_settings_page_loads_defaults(tmp_path: Path) -> None:
     assert "Enable OpenHands agent mode" in html
     assert "Enable Claude Agent SDK mode" in html
     assert "Claude Agent runtime" in html
+    assert "software-factory/claude-agent:latest" in html
 
 
 def test_save_settings_updates_feature_flags(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a repo-owned Dockerfile for the Claude agent runtime image
- set the default Claude agent container image to `software-factory/claude-agent:latest`
- cover the default image value in settings tests

## Validation
- pytest -q
- docker build -t software-factory/claude-agent:latest -f docker/claude-agent/Dockerfile .
