### PR TITLE
fix: refresh run heartbeat while logging

### DIFF
--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -38,6 +38,7 @@ from app.services.queue import (
     get_run_status,
     is_run_cancel_requested,
     mark_run_finished,
+    touch_run_progress,
     update_run_logs_path,
 )
 from app.services.retry import RetryConfig, schedule_retry
@@ -164,24 +165,33 @@ class RunLogger:
     workspace_dir: str
     run_id: int
     lines: list[str]
+    on_progress: Callable[[str], None] | None = None
     logs_path: str = field(init=False)
 
     def __post_init__(self) -> None:
         self.logs_path = _write_logs(self.workspace_dir, self.run_id, self.lines)
+        self._notify_progress()
 
     def append(self, line: str) -> None:
         self.lines.append(line)
         _append_logs(self.logs_path, [line])
+        self._notify_progress()
 
     def extend(self, new_lines: list[str]) -> None:
         if not new_lines:
             return
         self.lines.extend(new_lines)
         _append_logs(self.logs_path, new_lines)
+        self._notify_progress()
 
     def flush(self) -> str:
         self.logs_path = _write_logs(self.workspace_dir, self.run_id, self.lines)
+        self._notify_progress()
         return self.logs_path
+
+    def _notify_progress(self) -> None:
+        if self.on_progress is not None:
+            self.on_progress(self.logs_path)
 
 
 def run_once(
@@ -274,7 +284,12 @@ def run_once(
         prompt,
         "",
     ]
-    logger = RunLogger(workspace_dir=workspace, run_id=run_id, lines=log_lines)
+    logger = RunLogger(
+        workspace_dir=workspace,
+        run_id=run_id,
+        lines=log_lines,
+        on_progress=lambda logs_path: touch_run_progress(conn, run_id, logs_path=logs_path),
+    )
     update_run_logs_path(conn, run_id, logger.logs_path)
     lock_acquired = acquire_pr_lock(
         conn=conn,

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -191,6 +191,34 @@ def update_run_logs_path(conn: sqlite3.Connection, run_id: int, logs_path: str) 
     conn.commit()
 
 
+def touch_run_progress(
+    conn: sqlite3.Connection,
+    run_id: int,
+    *,
+    logs_path: str | None = None,
+) -> None:
+    if logs_path is None:
+        conn.execute(
+            """
+            UPDATE autofix_runs
+            SET updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (run_id,),
+        )
+    else:
+        conn.execute(
+            """
+            UPDATE autofix_runs
+            SET logs_path = ?,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (logs_path, run_id),
+        )
+    conn.commit()
+
+
 def get_run_status(conn: sqlite3.Connection, run_id: int) -> str | None:
     row = conn.execute(
         "SELECT status FROM autofix_runs WHERE id = ?",

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -8,6 +8,7 @@ from app.services.queue import (
     enqueue_autofix_run,
     mark_run_finished,
     recover_stale_runs,
+    touch_run_progress,
 )
 
 
@@ -124,3 +125,34 @@ def test_recover_stale_runs_marks_old_running_rows_failed() -> None:
     assert rows[0]["last_error_code"] == "stale_run_recovered"
     assert rows[1]["status"] == "failed"
     assert rows[2]["status"] == "running"
+
+
+def test_touch_run_progress_updates_timestamp_and_logs_path() -> None:
+    conn = _make_conn()
+    run_id = enqueue_autofix_run(
+        conn=conn,
+        repo="acme/widgets",
+        pr_number=42,
+        head_sha="abc123",
+        normalized_review_json={"summary": "1 blocking issue"},
+    )
+    assert run_id is not None
+
+    before = conn.execute(
+        "SELECT updated_at, logs_path FROM autofix_runs WHERE id = ?",
+        (run_id,),
+    ).fetchone()
+    assert before is not None
+
+    conn.execute("UPDATE autofix_runs SET updated_at = '2000-01-01 00:00:00' WHERE id = ?", (run_id,))
+    conn.commit()
+
+    touch_run_progress(conn, run_id, logs_path="logs/autofix-run-42.log")
+
+    after = conn.execute(
+        "SELECT updated_at, logs_path FROM autofix_runs WHERE id = ?",
+        (run_id,),
+    ).fetchone()
+    assert after is not None
+    assert after["logs_path"] == "logs/autofix-run-42.log"
+    assert after["updated_at"] != "2000-01-01 00:00:00"


### PR DESCRIPTION
## Summary
- add a lightweight queue heartbeat helper for in-progress runs
- refresh `updated_at` whenever the run logger appends or flushes log output
- cover the heartbeat update in queue tests

## Validation
- pytest -q tests/test_queue.py tests/test_agent_runner.py
