### PR TITLE
feat: default claude agent to openrouter

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -49,10 +49,13 @@ class Settings(BaseSettings):
     agent_sdks: tuple[str, ...] = ("claude_agent_sdk", "openhands")
     openhands_command: str = "openhands"
     claude_agent_sdk_command: str = "claude"
+    claude_agent_sdk_provider: str = "openrouter"
+    claude_agent_sdk_base_url: str = "https://openrouter.ai/api"
+    claude_agent_sdk_model: str = "openrouter/hunter-alpha"
     claude_agent_sdk_runtime: str = "host"
     claude_agent_sdk_container_image: str = "software-factory/claude-agent:latest"
     openhands_command_timeout_seconds: int = 600
-    claude_agent_sdk_command_timeout_seconds: int = 600
+    claude_agent_sdk_command_timeout_seconds: int = 1800
     openhands_worktree_base_dir: str = ".software-factory-worktrees"
     claude_agent_sdk_worktree_base_dir: str = ".software-factory-worktrees"
 

--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -503,6 +503,13 @@ async def save_settings(request: Request) -> RedirectResponse:
 
     openhands_command = str(form.get("openhands_command", "openhands")).strip()
     claude_agent_command = str(form.get("claude_agent_command", "claude")).strip()
+    claude_agent_provider = str(form.get("claude_agent_provider", "openrouter")).strip()
+    claude_agent_base_url = str(
+        form.get("claude_agent_base_url", "https://openrouter.ai/api")
+    ).strip()
+    claude_agent_model = str(
+        form.get("claude_agent_model", "openrouter/hunter-alpha")
+    ).strip()
     claude_agent_runtime = str(form.get("claude_agent_runtime", "host")).strip()
     claude_agent_container_image = str(
         form.get("claude_agent_container_image", "")
@@ -519,12 +526,12 @@ async def save_settings(request: Request) -> RedirectResponse:
     except (TypeError, ValueError):
         openhands_command_timeout_seconds = 600
     claude_timeout_raw = str(
-        form.get("claude_agent_command_timeout_seconds", "600")
+        form.get("claude_agent_command_timeout_seconds", "1800")
     ).strip()
     try:
         claude_agent_command_timeout_seconds = max(1, int(claude_timeout_raw))
     except (TypeError, ValueError):
-        claude_agent_command_timeout_seconds = 600
+        claude_agent_command_timeout_seconds = 1800
 
     with connect_db() as conn:
         save_agent_feature_flags(
@@ -535,6 +542,9 @@ async def save_settings(request: Request) -> RedirectResponse:
             openhands_command_timeout_seconds=openhands_command_timeout_seconds,
             openhands_worktree_base_dir=openhands_worktree_base_dir,
             claude_agent_command=claude_agent_command,
+            claude_agent_provider=claude_agent_provider,
+            claude_agent_base_url=claude_agent_base_url,
+            claude_agent_model=claude_agent_model,
             claude_agent_runtime=claude_agent_runtime,
             claude_agent_container_image=claude_agent_container_image,
             claude_agent_command_timeout_seconds=(

--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -412,6 +412,9 @@ def run_once(
                     feature_flags.openhands_command_timeout_seconds
                 ),
                 claude_agent_command=feature_flags.claude_agent_command,
+                claude_agent_provider=feature_flags.claude_agent_provider,
+                claude_agent_base_url=feature_flags.claude_agent_base_url,
+                claude_agent_model=feature_flags.claude_agent_model,
                 claude_agent_runtime=feature_flags.claude_agent_runtime,
                 claude_agent_container_image=(
                     feature_flags.claude_agent_container_image
@@ -762,6 +765,9 @@ def _execute_agent_sdks(
     openhands_command: str,
     openhands_command_timeout_seconds: int,
     claude_agent_command: str,
+    claude_agent_provider: str,
+    claude_agent_base_url: str,
+    claude_agent_model: str,
     claude_agent_runtime: str,
     claude_agent_container_image: str,
     claude_agent_command_timeout_seconds: int,
@@ -803,6 +809,9 @@ def _execute_agent_sdks(
                 "pr_number": pr_number,
                 "prompt": prompt,
                 "command": claude_agent_command,
+                "provider": claude_agent_provider,
+                "base_url": claude_agent_base_url,
+                "model": claude_agent_model,
                 "runtime": claude_agent_runtime,
                 "container_image": claude_agent_container_image,
                 "timeout_seconds": claude_agent_command_timeout_seconds,
@@ -857,6 +866,9 @@ def _run_claude_agent(
     prompt: str,
     *,
     command: str,
+    provider: str,
+    base_url: str,
+    model: str,
     runtime: str,
     container_image: str,
     timeout_seconds: int,
@@ -871,6 +883,9 @@ def _run_claude_agent(
             pr_number=pr_number,
             prompt=prompt,
             command=command,
+            provider=provider,
+            base_url=base_url,
+            model=model,
             container_image=container_image,
             timeout_seconds=timeout_seconds,
             agent_name="Claude Agent SDK",
@@ -885,6 +900,9 @@ def _run_claude_agent(
         pr_number=pr_number,
         prompt=prompt,
         command=command,
+        provider=provider,
+        base_url=base_url,
+        model=model,
         timeout_seconds=timeout_seconds,
         agent_name="Claude Agent SDK",
         failure_code=CLAUDE_FAILURE_CODE_COMMAND,
@@ -901,6 +919,9 @@ def _run_claude_container_command(
     pr_number: int,
     prompt: str,
     command: str,
+    provider: str,
+    base_url: str,
+    model: str,
     container_image: str,
     timeout_seconds: int,
     agent_name: str,
@@ -933,6 +954,9 @@ def _run_claude_container_command(
         repo=repo,
         pr_number=pr_number,
         run_id=run_id,
+        provider=provider,
+        base_url=base_url,
+        model=model,
     )
     argv = _build_claude_container_command_argv(
         workspace=workspace,
@@ -968,6 +992,9 @@ def _run_claude_stream_command(
     pr_number: int,
     prompt: str,
     command: str,
+    provider: str,
+    base_url: str,
+    model: str,
     timeout_seconds: int,
     agent_name: str,
     failure_code: str,
@@ -1003,7 +1030,14 @@ def _run_claude_stream_command(
         failure_code=failure_code,
         on_log_line=on_log_line,
         should_cancel=should_cancel,
-        process_env=_build_agent_environment(repo=repo, pr_number=pr_number, run_id=run_id),
+        process_env=_build_claude_agent_environment(
+            repo=repo,
+            pr_number=pr_number,
+            run_id=run_id,
+            provider=provider,
+            base_url=base_url,
+            model=model,
+        ),
     )
 
 
@@ -1181,8 +1215,18 @@ def _build_claude_container_environment(
     repo: str,
     pr_number: int,
     run_id: int,
+    provider: str,
+    base_url: str,
+    model: str,
 ) -> dict[str, str]:
-    env = _build_agent_environment(repo=repo, pr_number=pr_number, run_id=run_id)
+    env = _build_claude_agent_environment(
+        repo=repo,
+        pr_number=pr_number,
+        run_id=run_id,
+        provider=provider,
+        base_url=base_url,
+        model=model,
+    )
     env["HOME"] = "/tmp/claude-home"
     env["XDG_CONFIG_HOME"] = "/tmp/claude-home/.config"
     env["XDG_CACHE_HOME"] = "/tmp/claude-home/.cache"
@@ -1549,6 +1593,18 @@ def _terminate_agent_process_tree_by_pid(pid: int) -> None:
     except OSError:
         return
 
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        try:
+            os.killpg(pid, 0)
+        except ProcessLookupError:
+            with _ACTIVE_AGENT_PIDS_LOCK:
+                _ACTIVE_AGENT_PIDS.discard(pid)
+            return
+        except OSError:
+            break
+        time.sleep(0.1)
+
     try:
         os.killpg(pid, signal.SIGKILL)
     except ProcessLookupError:
@@ -1570,6 +1626,39 @@ def _build_agent_environment(*, repo: str, pr_number: int, run_id: int) -> dict[
     env["SOFTWARE_FACTORY_REPO"] = repo
     env["SOFTWARE_FACTORY_PR_NUMBER"] = str(pr_number)
     env["SOFTWARE_FACTORY_RUN_ID"] = str(run_id)
+    return env
+
+
+def _build_claude_agent_environment(
+    *,
+    repo: str,
+    pr_number: int,
+    run_id: int,
+    provider: str,
+    base_url: str,
+    model: str,
+) -> dict[str, str]:
+    env = _build_agent_environment(repo=repo, pr_number=pr_number, run_id=run_id)
+    normalized_provider = str(provider).strip().lower()
+    normalized_base_url = str(base_url).strip()
+    normalized_model = str(model).strip()
+
+    if normalized_provider == "deepseek":
+        deepseek_key = str(os.environ.get("DEEPSEEK_API_KEY", "")).strip()
+        if deepseek_key:
+            env["ANTHROPIC_AUTH_TOKEN"] = deepseek_key
+            env["ANTHROPIC_API_KEY"] = deepseek_key
+    else:
+        openrouter_key = str(os.environ.get("OPENROUTER_API_KEY", "")).strip()
+        if openrouter_key:
+            env["ANTHROPIC_AUTH_TOKEN"] = openrouter_key
+        env["ANTHROPIC_API_KEY"] = ""
+
+    if normalized_base_url:
+        env["ANTHROPIC_BASE_URL"] = normalized_base_url
+    if normalized_model:
+        env["ANTHROPIC_MODEL"] = normalized_model
+        env["ANTHROPIC_SMALL_FAST_MODEL"] = normalized_model
     return env
 
 

--- a/app/services/feature_flags.py
+++ b/app/services/feature_flags.py
@@ -12,6 +12,9 @@ FEATURE_FLAG_OPENHANDS_TIMEOUT_KEY = "agent.openhands.command_timeout_seconds"
 FEATURE_FLAG_OPENHANDS_WORKTREE_DIR_KEY = "agent.openhands.worktree_base_dir"
 FEATURE_FLAG_CLAUDE_AGENT_ENABLED_KEY = "agent.claude_agent.enabled"
 FEATURE_FLAG_CLAUDE_AGENT_COMMAND_KEY = "agent.claude_agent.command"
+FEATURE_FLAG_CLAUDE_AGENT_PROVIDER_KEY = "agent.claude_agent.provider"
+FEATURE_FLAG_CLAUDE_AGENT_BASE_URL_KEY = "agent.claude_agent.base_url"
+FEATURE_FLAG_CLAUDE_AGENT_MODEL_KEY = "agent.claude_agent.model"
 FEATURE_FLAG_CLAUDE_AGENT_RUNTIME_KEY = "agent.claude_agent.runtime"
 FEATURE_FLAG_CLAUDE_AGENT_CONTAINER_IMAGE_KEY = "agent.claude_agent.container_image"
 FEATURE_FLAG_CLAUDE_AGENT_TIMEOUT_KEY = "agent.claude_agent.command_timeout_seconds"
@@ -21,6 +24,8 @@ FEATURE_FLAG_LEGACY_ENABLED_KEY = "agent.legacy.enabled"
 OPENHANDS_AGENT_MODE = "openhands"
 CLAUDE_AGENT_MODE = "claude_agent_sdk"
 LEGACY_AGENT_MODE = "legacy"
+CLAUDE_AGENT_PROVIDER_OPENROUTER = "openrouter"
+CLAUDE_AGENT_PROVIDER_DEEPSEEK = "deepseek"
 CLAUDE_AGENT_RUNTIME_HOST = "host"
 CLAUDE_AGENT_RUNTIME_DOCKER = "docker"
 
@@ -32,6 +37,9 @@ class AgentFeatureFlags:
     openhands_command_timeout_seconds: int
     openhands_worktree_base_dir: str
     claude_agent_command: str
+    claude_agent_provider: str
+    claude_agent_base_url: str
+    claude_agent_model: str
     claude_agent_runtime: str
     claude_agent_container_image: str
     claude_agent_command_timeout_seconds: int
@@ -59,6 +67,9 @@ def get_default_agent_feature_flags() -> AgentFeatureFlags:
         ),
         openhands_command=settings.openhands_command.strip() or "openhands",
         claude_agent_command=settings.claude_agent_sdk_command.strip() or "claude",
+        claude_agent_provider=_normalize_provider(settings.claude_agent_sdk_provider),
+        claude_agent_base_url=settings.claude_agent_sdk_base_url.strip(),
+        claude_agent_model=settings.claude_agent_sdk_model.strip(),
         claude_agent_runtime=_normalize_runtime(settings.claude_agent_sdk_runtime),
         claude_agent_container_image=settings.claude_agent_sdk_container_image.strip(),
         openhands_command_timeout_seconds=settings.openhands_command_timeout_seconds,
@@ -126,6 +137,17 @@ def resolve_agent_feature_flags(
         FEATURE_FLAG_CLAUDE_AGENT_COMMAND_KEY,
         settings.claude_agent_command,
     ).strip() or settings.claude_agent_command
+    claude_provider = _normalize_provider(
+        raw_flags.get(FEATURE_FLAG_CLAUDE_AGENT_PROVIDER_KEY, settings.claude_agent_provider)
+    )
+    claude_base_url = raw_flags.get(
+        FEATURE_FLAG_CLAUDE_AGENT_BASE_URL_KEY,
+        settings.claude_agent_base_url,
+    ).strip() or settings.claude_agent_base_url
+    claude_model = raw_flags.get(
+        FEATURE_FLAG_CLAUDE_AGENT_MODEL_KEY,
+        settings.claude_agent_model,
+    ).strip() or settings.claude_agent_model
     claude_runtime = _normalize_runtime(
         raw_flags.get(FEATURE_FLAG_CLAUDE_AGENT_RUNTIME_KEY, settings.claude_agent_runtime)
     )
@@ -150,6 +172,9 @@ def resolve_agent_feature_flags(
         openhands_command_timeout_seconds=openhands_timeout,
         openhands_worktree_base_dir=worktree_dir,
         claude_agent_command=claude_command,
+        claude_agent_provider=claude_provider,
+        claude_agent_base_url=claude_base_url,
+        claude_agent_model=claude_model,
         claude_agent_runtime=claude_runtime,
         claude_agent_container_image=claude_container_image,
         claude_agent_command_timeout_seconds=claude_timeout,
@@ -166,6 +191,9 @@ def save_agent_feature_flags(
     openhands_command_timeout_seconds: int,
     openhands_worktree_base_dir: str,
     claude_agent_command: str,
+    claude_agent_provider: str,
+    claude_agent_base_url: str,
+    claude_agent_model: str,
     claude_agent_runtime: str,
     claude_agent_container_image: str,
     claude_agent_command_timeout_seconds: int,
@@ -185,6 +213,18 @@ def save_agent_feature_flags(
             openhands_worktree_base_dir.strip() or ".software-factory-worktrees",
         ),
         (FEATURE_FLAG_CLAUDE_AGENT_COMMAND_KEY, claude_agent_command.strip()),
+        (
+            FEATURE_FLAG_CLAUDE_AGENT_PROVIDER_KEY,
+            _normalize_provider(claude_agent_provider),
+        ),
+        (
+            FEATURE_FLAG_CLAUDE_AGENT_BASE_URL_KEY,
+            claude_agent_base_url.strip(),
+        ),
+        (
+            FEATURE_FLAG_CLAUDE_AGENT_MODEL_KEY,
+            claude_agent_model.strip(),
+        ),
         (
             FEATURE_FLAG_CLAUDE_AGENT_RUNTIME_KEY,
             _normalize_runtime(claude_agent_runtime),
@@ -230,6 +270,9 @@ def build_feature_flag_context(conn: sqlite3.Connection) -> Mapping[str, Any]:
         "openhands_command_timeout_seconds": str(flags.openhands_command_timeout_seconds),
         "openhands_worktree_base_dir": flags.openhands_worktree_base_dir,
         "claude_agent_command": flags.claude_agent_command,
+        "claude_agent_provider": flags.claude_agent_provider,
+        "claude_agent_base_url": flags.claude_agent_base_url,
+        "claude_agent_model": flags.claude_agent_model,
         "claude_agent_runtime": flags.claude_agent_runtime,
         "claude_agent_container_image": flags.claude_agent_container_image,
         "claude_agent_command_timeout_seconds": str(
@@ -300,3 +343,10 @@ def _normalize_runtime(value: str | None) -> str:
     if normalized == CLAUDE_AGENT_RUNTIME_DOCKER:
         return CLAUDE_AGENT_RUNTIME_DOCKER
     return CLAUDE_AGENT_RUNTIME_HOST
+
+
+def _normalize_provider(value: str | None) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized == CLAUDE_AGENT_PROVIDER_DEEPSEEK:
+        return CLAUDE_AGENT_PROVIDER_DEEPSEEK
+    return CLAUDE_AGENT_PROVIDER_OPENROUTER

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -81,6 +81,31 @@
               autocomplete="off"
             >
 
+            <label for="claude_agent_provider">Claude Agent provider</label>
+            <select id="claude_agent_provider" name="claude_agent_provider">
+              <option value="openrouter" {% if claude_agent_provider == "openrouter" %}selected{% endif %}>OpenRouter</option>
+              <option value="deepseek" {% if claude_agent_provider == "deepseek" %}selected{% endif %}>DeepSeek</option>
+            </select>
+            <p class="muted tiny">Default provider is OpenRouter with Hunter Alpha.</p>
+
+            <label for="claude_agent_base_url">Claude Agent base URL</label>
+            <input
+              type="text"
+              id="claude_agent_base_url"
+              name="claude_agent_base_url"
+              value="{{ claude_agent_base_url }}"
+              autocomplete="off"
+            >
+
+            <label for="claude_agent_model">Claude Agent model</label>
+            <input
+              type="text"
+              id="claude_agent_model"
+              name="claude_agent_model"
+              value="{{ claude_agent_model }}"
+              autocomplete="off"
+            >
+
             <label for="claude_agent_runtime">Claude Agent runtime</label>
             <select id="claude_agent_runtime" name="claude_agent_runtime">
               <option value="host" {% if claude_agent_runtime == "host" %}selected{% endif %}>Host</option>

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -673,6 +673,9 @@ def test_execute_agent_sdks_falls_back_to_claude(monkeypatch: pytest.MonkeyPatch
         prompt: str,
         *,
         command: str,
+        provider: str,
+        base_url: str,
+        model: str,
         runtime: str,
         container_image: str,
         timeout_seconds: int,
@@ -695,6 +698,9 @@ def test_execute_agent_sdks_falls_back_to_claude(monkeypatch: pytest.MonkeyPatch
         openhands_command="openhands",
         openhands_command_timeout_seconds=600,
         claude_agent_command="claude",
+        claude_agent_provider="openrouter",
+        claude_agent_base_url="https://openrouter.ai/api",
+        claude_agent_model="openrouter/hunter-alpha",
         claude_agent_runtime="host",
         claude_agent_container_image="",
         claude_agent_command_timeout_seconds=600,
@@ -719,6 +725,9 @@ def test_execute_agent_sdks_does_not_fall_back_to_openhands_after_claude_failure
         prompt: str,
         *,
         command: str,
+        provider: str,
+        base_url: str,
+        model: str,
         runtime: str,
         container_image: str,
         timeout_seconds: int,
@@ -745,6 +754,9 @@ def test_execute_agent_sdks_does_not_fall_back_to_openhands_after_claude_failure
         openhands_command="openhands",
         openhands_command_timeout_seconds=600,
         claude_agent_command="claude",
+        claude_agent_provider="openrouter",
+        claude_agent_base_url="https://openrouter.ai/api",
+        claude_agent_model="openrouter/hunter-alpha",
         claude_agent_runtime="host",
         claude_agent_container_image="",
         claude_agent_command_timeout_seconds=600,
@@ -787,6 +799,7 @@ def test_run_claude_agent_uses_normalized_command_and_filtered_env(
             return f"<_FakeProcess returncode={self.returncode}>"
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
     monkeypatch.setenv("UNRELATED_SECRET", "should-not-leak")
     monkeypatch.setenv("PATH", os.environ.get("PATH", ""))
     monkeypatch.setattr(agent_runner.shutil, "which", lambda value: f"/usr/bin/{value}")
@@ -799,6 +812,9 @@ def test_run_claude_agent_uses_normalized_command_and_filtered_env(
         pr_number=7,
         prompt="fix this",
         command="  claude --print  ",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api",
+        model="openrouter/hunter-alpha",
         runtime="host",
         container_image="",
         timeout_seconds=42,
@@ -829,6 +845,12 @@ def test_run_claude_agent_uses_normalized_command_and_filtered_env(
     env = captured["env"]
     assert isinstance(env, dict)
     assert env["OPENAI_API_KEY"] == "test-openai-key"
+    assert env["OPENROUTER_API_KEY"] == "test-openrouter-key"
+    assert env["ANTHROPIC_BASE_URL"] == "https://openrouter.ai/api"
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "test-openrouter-key"
+    assert env["ANTHROPIC_API_KEY"] == ""
+    assert env["ANTHROPIC_MODEL"] == "openrouter/hunter-alpha"
+    assert env["ANTHROPIC_SMALL_FAST_MODEL"] == "openrouter/hunter-alpha"
     assert env["SOFTWARE_FACTORY_REPO"] == "acme/widgets"
     assert env["SOFTWARE_FACTORY_PR_NUMBER"] == "7"
     assert env["SOFTWARE_FACTORY_RUN_ID"] == "9"
@@ -861,6 +883,7 @@ def test_run_claude_agent_supports_docker_runtime(
             return self.returncode
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
     monkeypatch.setattr(agent_runner.subprocess, "Popen", _FakeProcess)
     monkeypatch.setattr(
         agent_runner.shutil,
@@ -881,6 +904,9 @@ def test_run_claude_agent_supports_docker_runtime(
         pr_number=7,
         prompt="fix this",
         command="claude",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api",
+        model="openrouter/hunter-alpha",
         runtime="docker",
         container_image="ghcr.io/example/claude-code:latest",
         timeout_seconds=42,
@@ -913,6 +939,10 @@ def test_run_claude_agent_supports_docker_runtime(
     env = captured["env"]
     assert isinstance(env, dict)
     assert env["OPENAI_API_KEY"] == "test-openai-key"
+    assert env["OPENROUTER_API_KEY"] == "test-openrouter-key"
+    assert env["ANTHROPIC_BASE_URL"] == "https://openrouter.ai/api"
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "test-openrouter-key"
+    assert env["ANTHROPIC_API_KEY"] == ""
     assert env["HOME"] == "/tmp/claude-home"
 
 
@@ -928,6 +958,9 @@ def test_run_claude_agent_rejects_shell_control_tokens(tmp_path: Path) -> None:
         pr_number=7,
         prompt="fix this",
         command="claude && whoami",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api",
+        model="openrouter/hunter-alpha",
         runtime="host",
         container_image="",
         timeout_seconds=42,

--- a/tests/test_web_settings.py
+++ b/tests/test_web_settings.py
@@ -31,7 +31,9 @@ def test_settings_page_loads_defaults(tmp_path: Path) -> None:
     assert "System Settings" in html
     assert "Enable OpenHands agent mode" in html
     assert "Enable Claude Agent SDK mode" in html
+    assert "Claude Agent provider" in html
     assert "Claude Agent runtime" in html
+    assert "openrouter/hunter-alpha" in html
     assert "software-factory/claude-agent:latest" in html
 
 
@@ -48,6 +50,9 @@ def test_save_settings_updates_feature_flags(tmp_path: Path) -> None:
                 "openhands_command_timeout_seconds": "123",
                 "openhands_worktree_base_dir": "tmp/worktrees",
                 "claude_agent_command": "claude-test",
+                "claude_agent_provider": "deepseek",
+                "claude_agent_base_url": "https://api.deepseek.com/anthropic",
+                "claude_agent_model": "deepseek-chat",
                 "claude_agent_runtime": "docker",
                 "claude_agent_container_image": "ghcr.io/example/claude-code:latest",
                 "claude_agent_command_timeout_seconds": "222",
@@ -71,6 +76,9 @@ def test_save_settings_updates_feature_flags(tmp_path: Path) -> None:
     assert flags["agent.openhands.enabled"] == "1"
     assert flags["agent.claude_agent.enabled"] == "1"
     assert flags["agent.claude_agent.command"] == "claude-test"
+    assert flags["agent.claude_agent.provider"] == "deepseek"
+    assert flags["agent.claude_agent.base_url"] == "https://api.deepseek.com/anthropic"
+    assert flags["agent.claude_agent.model"] == "deepseek-chat"
     assert flags["agent.claude_agent.runtime"] == "docker"
     assert flags["agent.claude_agent.container_image"] == "ghcr.io/example/claude-code:latest"
     assert flags["agent.claude_agent.command_timeout_seconds"] == "222"
@@ -88,6 +96,9 @@ def test_save_settings_updates_feature_flags(tmp_path: Path) -> None:
     assert active_flags.openhands_command_timeout_seconds == 123
     assert active_flags.openhands_worktree_base_dir == "tmp/worktrees"
     assert active_flags.claude_agent_command == "claude-test"
+    assert active_flags.claude_agent_provider == "deepseek"
+    assert active_flags.claude_agent_base_url == "https://api.deepseek.com/anthropic"
+    assert active_flags.claude_agent_model == "deepseek-chat"
     assert active_flags.claude_agent_runtime == "docker"
     assert active_flags.claude_agent_container_image == "ghcr.io/example/claude-code:latest"
     assert active_flags.claude_agent_command_timeout_seconds == 222


### PR DESCRIPTION
## Summary
- default Claude Agent provider settings to OpenRouter with model 
- raise Claude command timeout to 1800 seconds and expose provider/base URL/model in settings
- harden Claude timeout cleanup so timed out process groups are terminated more reliably