### PR TITLE
fix: install gh in claude agent image

### DIFF
--- a/docker/claude-agent/Dockerfile
+++ b/docker/claude-agent/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
         bash \
         ca-certificates \
         curl \
+        gh \
         git \
         jq \
         openssh-client \


### PR DESCRIPTION
## Summary
- install GitHub CLI in the Claude agent container image so containerized agent runs can execute gh commands