### PR TITLE
fix: expose github auth to claude container

### DIFF
--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -1659,6 +1659,16 @@ def _build_claude_agent_environment(
     if normalized_model:
         env["ANTHROPIC_MODEL"] = normalized_model
         env["ANTHROPIC_SMALL_FAST_MODEL"] = normalized_model
+
+    gh_token = (
+        str(env.get("GH_TOKEN", "")).strip()
+        or str(env.get("GITHUB_TOKEN", "")).strip()
+        or str(env.get("GITHUB_PERSONAL_ACCESS_TOKEN", "")).strip()
+        or str(env.get("GITHUB_RELEASE_TOKEN", "")).strip()
+    )
+    if gh_token:
+        env["GH_TOKEN"] = gh_token
+        env["GITHUB_TOKEN"] = gh_token
     return env
 
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -800,6 +800,7 @@ def test_run_claude_agent_uses_normalized_command_and_filtered_env(
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+    monkeypatch.setenv("GITHUB_PERSONAL_ACCESS_TOKEN", "test-gh-pat")
     monkeypatch.setenv("UNRELATED_SECRET", "should-not-leak")
     monkeypatch.setenv("PATH", os.environ.get("PATH", ""))
     monkeypatch.setattr(agent_runner.shutil, "which", lambda value: f"/usr/bin/{value}")
@@ -851,6 +852,8 @@ def test_run_claude_agent_uses_normalized_command_and_filtered_env(
     assert env["ANTHROPIC_API_KEY"] == ""
     assert env["ANTHROPIC_MODEL"] == "openrouter/hunter-alpha"
     assert env["ANTHROPIC_SMALL_FAST_MODEL"] == "openrouter/hunter-alpha"
+    assert env["GH_TOKEN"] == "test-gh-pat"
+    assert env["GITHUB_TOKEN"] == "test-gh-pat"
     assert env["SOFTWARE_FACTORY_REPO"] == "acme/widgets"
     assert env["SOFTWARE_FACTORY_PR_NUMBER"] == "7"
     assert env["SOFTWARE_FACTORY_RUN_ID"] == "9"
@@ -884,6 +887,7 @@ def test_run_claude_agent_supports_docker_runtime(
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+    monkeypatch.setenv("GITHUB_PERSONAL_ACCESS_TOKEN", "test-gh-pat")
     monkeypatch.setattr(agent_runner.subprocess, "Popen", _FakeProcess)
     monkeypatch.setattr(
         agent_runner.shutil,
@@ -943,6 +947,8 @@ def test_run_claude_agent_supports_docker_runtime(
     assert env["ANTHROPIC_BASE_URL"] == "https://openrouter.ai/api"
     assert env["ANTHROPIC_AUTH_TOKEN"] == "test-openrouter-key"
     assert env["ANTHROPIC_API_KEY"] == ""
+    assert env["GH_TOKEN"] == "test-gh-pat"
+    assert env["GITHUB_TOKEN"] == "test-gh-pat"
     assert env["HOME"] == "/tmp/claude-home"
 
 


### PR DESCRIPTION
## Summary
- map existing GitHub token env vars to GH_TOKEN/GITHUB_TOKEN for containerized Claude runs
- keep the auth mapping covered by agent runner tests