### PR TITLE
fix: record pushed pr branch in autofix runs

### DIFF
--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -684,7 +684,10 @@ def _finalize_git_changes(
     )
     if commit_result.get("success"):
         commit_sha = _safe_text(commit_result.get("commit_sha"))
-        log_lines.append(f"git_push: success commit={commit_sha or 'unknown'}")
+        pushed_ref = _safe_text(commit_result.get("pushed_ref")) or "unknown"
+        log_lines.append(
+            f"git_push: success ref={pushed_ref} commit={commit_sha or 'unknown'}"
+        )
         return "success", commit_sha, None
 
     error = _safe_text(commit_result.get("error")) or "unknown_git_error"
@@ -692,8 +695,16 @@ def _finalize_git_changes(
         log_lines.append("git_push: skipped no_changes")
         return "success", None, None
 
-    log_lines.append(f"git_push: failed error={error}")
-    return "failed", _safe_text(commit_result.get("commit_sha")), f"git_failed: {error}"
+    error_stage = _safe_text(commit_result.get("error_stage")) or "git"
+    pushed_ref = _safe_text(commit_result.get("pushed_ref"))
+    if pushed_ref:
+        log_lines.append(
+            f"git_push: failed stage={error_stage} ref={pushed_ref} error={error}"
+        )
+    else:
+        log_lines.append(f"git_push: failed stage={error_stage} error={error}")
+    error_prefix = "git_push_failed" if error_stage == "git_push" else "git_commit_failed"
+    return "failed", _safe_text(commit_result.get("commit_sha")), f"{error_prefix}: {error}"
 
 
 def _run_validation_cycle(

--- a/app/services/git_ops.py
+++ b/app/services/git_ops.py
@@ -68,16 +68,32 @@ def commit_and_push(
             "success": False,
             "commit_sha": None,
             "error": _pick_message(add_result),
+            "error_stage": "git_add",
+            "remote": remote,
+            "branch": branch,
+            "pushed_ref": None,
         }
 
     diff_result = _run_git(repo_dir, ["diff", "--cached", "--quiet"])
     if diff_result.returncode == 0:
-        return {"success": False, "commit_sha": None, "error": "no_changes"}
+        return {
+            "success": False,
+            "commit_sha": None,
+            "error": "no_changes",
+            "error_stage": "git_diff",
+            "remote": remote,
+            "branch": branch,
+            "pushed_ref": None,
+        }
     if diff_result.returncode != 1:
         return {
             "success": False,
             "commit_sha": None,
             "error": _pick_message(diff_result),
+            "error_stage": "git_diff",
+            "remote": remote,
+            "branch": branch,
+            "pushed_ref": None,
         }
 
     commit_result = _run_git(repo_dir, ["commit", "-m", message])
@@ -86,6 +102,10 @@ def commit_and_push(
             "success": False,
             "commit_sha": None,
             "error": _pick_message(commit_result),
+            "error_stage": "git_commit",
+            "remote": remote,
+            "branch": branch,
+            "pushed_ref": None,
         }
 
     sha_result = _run_git(repo_dir, ["rev-parse", "HEAD"])
@@ -94,11 +114,23 @@ def commit_and_push(
             "success": False,
             "commit_sha": None,
             "error": _pick_message(sha_result),
+            "error_stage": "git_rev_parse",
+            "remote": remote,
+            "branch": branch,
+            "pushed_ref": None,
         }
 
     commit_sha = sha_result.stdout.strip()
     if not commit_sha:
-        return {"success": False, "commit_sha": None, "error": "empty_commit_sha"}
+        return {
+            "success": False,
+            "commit_sha": None,
+            "error": "empty_commit_sha",
+            "error_stage": "git_rev_parse",
+            "remote": remote,
+            "branch": branch,
+            "pushed_ref": None,
+        }
 
     target_branch = branch
     if target_branch is None:
@@ -108,6 +140,10 @@ def commit_and_push(
                 "success": False,
                 "commit_sha": commit_sha,
                 "error": _pick_message(branch_result),
+                "error_stage": "git_branch",
+                "remote": remote,
+                "branch": None,
+                "pushed_ref": None,
             }
         target_branch = branch_result.stdout.strip()
         if not target_branch or target_branch == "HEAD":
@@ -115,6 +151,10 @@ def commit_and_push(
                 "success": False,
                 "commit_sha": commit_sha,
                 "error": "detached_head",
+                "error_stage": "git_branch",
+                "remote": remote,
+                "branch": target_branch or None,
+                "pushed_ref": None,
             }
 
     push_result = _run_git(repo_dir, ["push", remote, target_branch])
@@ -123,9 +163,21 @@ def commit_and_push(
             "success": False,
             "commit_sha": commit_sha,
             "error": _pick_message(push_result),
+            "error_stage": "git_push",
+            "remote": remote,
+            "branch": target_branch,
+            "pushed_ref": f"{remote}/{target_branch}",
         }
 
-    return {"success": True, "commit_sha": commit_sha, "error": None}
+    return {
+        "success": True,
+        "commit_sha": commit_sha,
+        "error": None,
+        "error_stage": None,
+        "remote": remote,
+        "branch": target_branch,
+        "pushed_ref": f"{remote}/{target_branch}",
+    }
 
 
 def post_pr_comment(

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -97,6 +97,7 @@ def test_run_once_success_writes_logs_and_marks_success(
     logs_path = Path(result["logs_path"])
     assert logs_path.exists()
     logs_text = logs_path.read_text(encoding="utf-8")
+    assert "git_push: success ref=origin/feature/test commit=deadbeef" in logs_text
     assert "pytest -q" in logs_text
     assert "ruff check ." in logs_text
     assert "mypy ." in logs_text
@@ -134,6 +135,10 @@ def test_run_once_failure_marks_failed_and_records_error(
             "success": True,
             "commit_sha": "deadbeef",
             "error": None,
+            "error_stage": None,
+            "remote": "origin",
+            "branch": "feature/test",
+            "pushed_ref": "origin/feature/test",
         },
         post_pr_comment=lambda *_: (True, "ok"),
     )
@@ -189,6 +194,10 @@ def test_run_once_returns_failed_checks_to_agent_and_retries(
             "success": True,
             "commit_sha": "deadbeef",
             "error": None,
+            "error_stage": None,
+            "remote": "origin",
+            "branch": "feature/test",
+            "pushed_ref": "origin/feature/test",
         },
         post_pr_comment=lambda *_: (True, "ok"),
         collect_check_commands=lambda *_: ["python -m ruff check ."],
@@ -241,6 +250,10 @@ def test_run_once_allows_push_when_only_preexisting_failures_remain(
             "success": True,
             "commit_sha": "deadbeef",
             "error": None,
+            "error_stage": None,
+            "remote": "origin",
+            "branch": "feature/test",
+            "pushed_ref": "origin/feature/test",
         },
         post_pr_comment=lambda *_: (True, "ok"),
         collect_check_commands=lambda *_: ["python -m mypy ."],
@@ -296,6 +309,10 @@ def test_run_once_fails_when_new_check_failures_are_introduced(
             "success": True,
             "commit_sha": "deadbeef",
             "error": None,
+            "error_stage": None,
+            "remote": "origin",
+            "branch": "feature/test",
+            "pushed_ref": "origin/feature/test",
         },
         post_pr_comment=lambda *_: (True, "ok"),
         collect_check_commands=lambda *_: ["python -m mypy ."],
@@ -579,6 +596,10 @@ def test_run_once_schedules_retry_for_git_failure(
             "success": False,
             "commit_sha": None,
             "error": "push_rejected",
+            "error_stage": "git_push",
+            "remote": "origin",
+            "branch": "feature/test",
+            "pushed_ref": "origin/feature/test",
         },
         post_pr_comment=lambda *_: (True, "ok"),
     )

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -124,7 +124,15 @@ def test_commit_and_push_returns_no_changes(monkeypatch) -> None:
     )
 
     result = git_ops.commit_and_push("/repo", "msg")
-    assert result == {"success": False, "commit_sha": None, "error": "no_changes"}
+    assert result == {
+        "success": False,
+        "commit_sha": None,
+        "error": "no_changes",
+        "error_stage": "git_diff",
+        "remote": "origin",
+        "branch": None,
+        "pushed_ref": None,
+    }
     assert calls == [
         ["git", "add", "-A"],
         ["git", "diff", "--cached", "--quiet"],
@@ -163,7 +171,15 @@ def test_commit_and_push_success_infers_current_branch(monkeypatch) -> None:
     )
 
     result = git_ops.commit_and_push("/repo", "feat: m5")
-    assert result == {"success": True, "commit_sha": "deadbeef", "error": None}
+    assert result == {
+        "success": True,
+        "commit_sha": "deadbeef",
+        "error": None,
+        "error_stage": None,
+        "remote": "origin",
+        "branch": "feature/m5",
+        "pushed_ref": "origin/feature/m5",
+    }
     assert calls[-1] == ["git", "push", "origin", "feature/m5"]
 
 
@@ -201,7 +217,15 @@ def test_commit_and_push_push_failure_uses_given_branch(monkeypatch) -> None:
         remote="upstream",
         branch="release/m5",
     )
-    assert result == {"success": False, "commit_sha": "deadbeef", "error": "rejected"}
+    assert result == {
+        "success": False,
+        "commit_sha": "deadbeef",
+        "error": "rejected",
+        "error_stage": "git_push",
+        "remote": "upstream",
+        "branch": "release/m5",
+        "pushed_ref": "upstream/release/m5",
+    }
     assert ["git", "rev-parse", "--abbrev-ref", "HEAD"] not in calls
 
 


### PR DESCRIPTION
## Summary
- record pushed remote ref for successful autofix pushes
- distinguish commit-stage failures from push-stage failures in run errors
- cover the new push metadata in git ops and agent runner tests