### PR TITLE
feat: add run list search and pagination

### DIFF
--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -32,19 +32,59 @@ from app.services.queue import enqueue_autofix_run, request_run_cancel
 router = APIRouter(tags=["web"])
 
 
-def _fetch_runs(limit: int = 20) -> list[dict[str, str]]:
+def _normalize_page(raw_value: str | None, *, default: int = 1) -> int:
+    try:
+        value = int((raw_value or "").strip())
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def _fetch_runs(
+    *,
+    page: int = 1,
+    page_size: int = 10,
+    query: str = "",
+) -> dict[str, Any]:
+    normalized_query = query.strip()
+    sql_where = ""
+    sql_params: list[Any] = []
+    if normalized_query:
+        like_value = f"%{normalized_query.lower()}%"
+        sql_where = """
+            WHERE
+                lower(repo) LIKE ?
+                OR lower(status) LIKE ?
+                OR CAST(id AS TEXT) LIKE ?
+                OR CAST(pr_number AS TEXT) LIKE ?
+        """
+        sql_params.extend([like_value, like_value, like_value, like_value])
+
+    offset = (page - 1) * page_size
     with connect_db() as conn:
+        count_row = conn.execute(
+            f"""
+            SELECT COUNT(*) AS total_count
+            FROM autofix_runs
+            {sql_where}
+            """,
+            tuple(sql_params),
+        ).fetchone()
         rows = conn.execute(
-            """
+            f"""
             SELECT id, repo, pr_number, status, created_at, updated_at
             FROM autofix_runs
+            {sql_where}
             ORDER BY id DESC
-            LIMIT ?
+            LIMIT ? OFFSET ?
             """,
-            (limit,),
+            tuple([*sql_params, page_size, offset]),
         ).fetchall()
 
-    return [
+    total_count = int(count_row["total_count"]) if count_row is not None else 0
+    total_pages = max(1, (total_count + page_size - 1) // page_size)
+    normalized_page = min(page, total_pages)
+    runs = [
         {
             "id": str(row["id"]),
             "repo": str(row["repo"]),
@@ -57,6 +97,18 @@ def _fetch_runs(limit: int = 20) -> list[dict[str, str]]:
         }
         for row in rows
     ]
+    return {
+        "items": runs,
+        "page": normalized_page,
+        "page_size": page_size,
+        "total_count": total_count,
+        "total_pages": total_pages,
+        "query": normalized_query,
+        "has_prev": normalized_page > 1,
+        "has_next": normalized_page < total_pages,
+        "prev_page": normalized_page - 1,
+        "next_page": normalized_page + 1,
+    }
 
 
 def _status_class(status: str) -> str:
@@ -359,13 +411,17 @@ def _enqueue_issue_fix(
 @router.get("/", response_class=HTMLResponse)
 async def index(request: Request) -> HTMLResponse:
     templates: Jinja2Templates = request.app.state.templates
+    query = str(request.query_params.get("q", "")).strip()
+    page = _normalize_page(request.query_params.get("page"))
+    run_page = _fetch_runs(page=page, page_size=10, query=query)
     return templates.TemplateResponse(
         request=request,
         name="index.html",
         context={
             "request": request,
             "title": "Software Factory",
-            "runs": _fetch_runs(),
+            "runs": run_page["items"],
+            "run_page": run_page,
         },
     )
 

--- a/app/static/app.css
+++ b/app/static/app.css
@@ -398,6 +398,40 @@ button:disabled {
   gap: 0.85rem;
 }
 
+.run-search-form {
+  margin: 0.85rem 0 0.4rem;
+}
+
+.run-search-label {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-weight: 600;
+}
+
+.run-search-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.run-search-controls input[type="text"] {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.55rem 0.65rem;
+  font-family: inherit;
+}
+
+.secondary-link {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.run-results-summary {
+  margin: 0 0 0.9rem;
+}
+
 .run-card {
   border: 1px solid var(--border);
   border-radius: 10px;
@@ -450,4 +484,48 @@ button:disabled {
 .status-pill.retry {
   color: #5f3a8d;
   background: #ece2ff;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.pagination-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 5.5rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: #fff;
+  font-weight: 600;
+}
+
+.pagination-link.disabled {
+  color: var(--muted);
+  background: #f3f4f6;
+  cursor: default;
+  text-decoration: none;
+}
+
+.pagination-current {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 680px) {
+  .run-search-controls,
+  .pagination {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .pagination-current {
+    text-align: center;
+  }
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,6 +22,30 @@
 
       <section>
         <h2>Run History</h2>
+        <form method="get" action="/" class="run-search-form">
+          <label for="run-search" class="run-search-label">Search runs</label>
+          <div class="run-search-controls">
+            <input
+              id="run-search"
+              type="text"
+              name="q"
+              value="{{ run_page.query }}"
+              placeholder="Search by run id, repo, PR number, or status">
+            <button type="submit">Search</button>
+            {% if run_page.query %}
+            <a href="/" class="secondary-link">Clear</a>
+            {% endif %}
+          </div>
+        </form>
+
+        <p class="muted run-results-summary">
+          Showing {{ runs|length }} of {{ run_page.total_count }} runs
+          {% if run_page.query %}
+          for "{{ run_page.query }}"
+          {% endif %}
+          · Page {{ run_page.page }} / {{ run_page.total_pages }}
+        </p>
+
         {% if runs and runs|length > 0 %}
         <ul class="run-list">
           {% for run in runs %}
@@ -50,6 +74,25 @@
           </li>
           {% endfor %}
         </ul>
+        <nav class="pagination" aria-label="Run history pages">
+          {% if run_page.has_prev %}
+          <a href="/?page={{ run_page.prev_page }}{% if run_page.query %}&q={{ run_page.query | urlencode }}{% endif %}" class="pagination-link">
+            Previous
+          </a>
+          {% else %}
+          <span class="pagination-link disabled">Previous</span>
+          {% endif %}
+
+          <span class="pagination-current">Page {{ run_page.page }} of {{ run_page.total_pages }}</span>
+
+          {% if run_page.has_next %}
+          <a href="/?page={{ run_page.next_page }}{% if run_page.query %}&q={{ run_page.query | urlencode }}{% endif %}" class="pagination-link">
+            Next
+          </a>
+          {% else %}
+          <span class="pagination-link disabled">Next</span>
+          {% endif %}
+        </nav>
         {% else %}
         <p class="empty">No runs yet.</p>
         {% endif %}


### PR DESCRIPTION
## Summary
- add homepage search for runs by id, repo, PR number, or status
- add pagination to the run history list
- keep the existing run card layout while improving navigation
