### PR TITLE
fix: guard workspace root cleanup

### DIFF
--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -1880,9 +1880,9 @@ def _cleanup_openhands_workspace(base_repo_dir: str, worktree_dir: str) -> None:
             worktree_dir,
         )
         return
-    if base_repo not in worktree_path.parents:
+    if not worktree_path.name.startswith(f"{WORKTREE_CMD_PREFIX}-"):
         logger.warning(
-            "refusing to clean workspace outside base repo: base_repo_dir=%s worktree_dir=%s",
+            "refusing to clean workspace with unexpected name: base_repo_dir=%s worktree_dir=%s",
             base_repo_dir,
             worktree_dir,
         )

--- a/scripts/run_worker.py
+++ b/scripts/run_worker.py
@@ -117,11 +117,6 @@ def main() -> int:
     parser.add_argument("--workspace-dir", default=str(ROOT))
     args = parser.parse_args()
 
-    workspace_error = _validate_workspace_dir(args.workspace_dir)
-    if workspace_error is not None:
-        print(f"invalid workspace_dir={args.workspace_dir}: {workspace_error}")
-        return 2
-
     init_db()
     recovered_count = _recover_stale_runs()
     if recovered_count:
@@ -133,7 +128,10 @@ def main() -> int:
     if args.once:
         workspace_error = _validate_workspace_dir(args.workspace_dir)
         if workspace_error is not None:
-            print(f"invalid workspace_dir={args.workspace_dir}: {workspace_error}")
+            print(
+                f"invalid workspace_dir={args.workspace_dir}: {workspace_error}",
+                file=sys.stderr,
+            )
             return 2
         _process_one(workspace_dir=args.workspace_dir)
         return 0
@@ -141,7 +139,10 @@ def main() -> int:
     while not _STOP_WORKER:
         workspace_error = _validate_workspace_dir(args.workspace_dir)
         if workspace_error is not None:
-            print(f"invalid workspace_dir={args.workspace_dir}: {workspace_error}")
+            print(
+                f"invalid workspace_dir={args.workspace_dir}: {workspace_error}",
+                file=sys.stderr,
+            )
             return 2
         processed = _process_one(workspace_dir=args.workspace_dir)
         if not processed:


### PR DESCRIPTION
## Summary
- refuse to clean the worker base workspace directory as if it were a per-run worktree
- refuse cleanup when the target path is outside the configured base repository
- make the worker exit early when --workspace-dir is missing or no longer a git worktree
