### PR TITLE
fix: propagate CI status into autofix context

### DIFF
--- a/app/routes/github.py
+++ b/app/routes/github.py
@@ -20,7 +20,6 @@ from app.services.github_events import (
 from app.services.policy import (
     ensure_pull_request_row,
     get_remaining_autofix_quota,
-    is_autofix_limit_reached,
     reset_autofix_count_on_sha_change,
 )
 from app.services.normalizer import normalize_review_events
@@ -55,6 +54,26 @@ async def _read_payload(request: Request) -> dict[str, Any]:
 def _get_debounce_backend() -> InMemoryDebounceBackend:
     window_seconds = get_settings().github_webhook_debounce_seconds
     return InMemoryDebounceBackend(window_seconds=window_seconds)
+
+
+def _should_enqueue_for_event(event_type: str) -> bool:
+    return event_type in {
+        "pull_request_review",
+        "pull_request_review_comment",
+        "issue_comment",
+    }
+
+
+def _get_filter_reason_for_event(
+    event_type: str,
+    *,
+    repo: str | None,
+    actor: str | None,
+    body: str | None,
+) -> str | None:
+    if _should_enqueue_for_event(event_type):
+        return get_filter_reason(repo, actor=actor, body=body)
+    return get_filter_reason(repo)
 
 
 @router.post("/webhook")
@@ -101,8 +120,9 @@ async def github_webhook(request: Request) -> dict[str, Any]:
             "repo": event.repo,
             "pr_number": event.pr_number,
         }
-    filter_reason = get_filter_reason(
-        event.repo,
+    filter_reason = _get_filter_reason_for_event(
+        event_type,
+        repo=event.repo,
         actor=None if should_ignore_actor else event.actor,
         body=event_body,
     )
@@ -148,33 +168,38 @@ async def github_webhook(request: Request) -> dict[str, Any]:
                     pr_number=event.pr_number,
                     head_sha=event.head_sha,
                 )
-                review_batch_id = build_review_batch_id(normalized_review)
-                normalized_review["review_batch_id"] = review_batch_id
-                idempotency_key = build_task_idempotency_key(
-                    repo=event.repo,
-                    pr_number=event.pr_number,
-                    head_sha=event.head_sha,
-                    review_batch_id=review_batch_id,
-                )
-                remaining_quota = get_remaining_autofix_quota(
-                    conn,
-                    event.repo,
-                    event.pr_number,
-                )
-                if remaining_quota == 0:
-                    queue_status = "autofix_limit_reached"
-                else:
-                    run_id = enqueue_autofix_run(
-                        conn=conn,
+                if _should_enqueue_for_event(event_type):
+                    review_batch_id = build_review_batch_id(normalized_review)
+                    normalized_review["review_batch_id"] = review_batch_id
+                    idempotency_key = build_task_idempotency_key(
                         repo=event.repo,
                         pr_number=event.pr_number,
                         head_sha=event.head_sha,
-                        normalized_review_json=normalized_review,
-                        trigger_source="github_webhook",
-                        idempotency_key=idempotency_key,
-                        max_attempts=get_settings().max_retry_attempts,
+                        review_batch_id=review_batch_id,
                     )
-                    queue_status = "queued" if run_id is not None else "duplicate_task"
+                    remaining_quota = get_remaining_autofix_quota(
+                        conn,
+                        event.repo,
+                        event.pr_number,
+                    )
+                    if remaining_quota == 0:
+                        queue_status = "autofix_limit_reached"
+                    else:
+                        run_id = enqueue_autofix_run(
+                            conn=conn,
+                            repo=event.repo,
+                            pr_number=event.pr_number,
+                            head_sha=event.head_sha,
+                            normalized_review_json=normalized_review,
+                            trigger_source="github_webhook",
+                            idempotency_key=idempotency_key,
+                            max_attempts=get_settings().max_retry_attempts,
+                        )
+                        queue_status = (
+                            "queued" if run_id is not None else "duplicate_task"
+                        )
+                else:
+                    queue_status = "recorded"
             else:
                 queue_status = "duplicate_event"
     except sqlite3.Error as exc:
@@ -244,9 +269,130 @@ def _build_normalized_review(
         events=events,
         head_sha=head_sha,
     )
+    ci_checks = _collect_ci_checks(events=events, head_sha=head_sha)
     normalized["branch"] = branch
     normalized["project_type"] = project_type or "python"
+    if ci_checks:
+        normalized["ci_checks"] = ci_checks
+        normalized["ci_status"] = _summarize_ci_status(ci_checks)
     return normalized
+
+
+def _collect_ci_checks(
+    *, events: list[dict[str, Any]], head_sha: str | None
+) -> list[dict[str, Any]]:
+    latest_by_key: dict[str, dict[str, Any]] = {}
+    for event in events:
+        event_type = event.get("event_type")
+        payload = event.get("payload")
+        if not isinstance(event_type, str) or not isinstance(payload, dict):
+            continue
+        extracted = _extract_ci_check(event_type, payload)
+        if extracted is None:
+            continue
+        event_head_sha = str(extracted.get("head_sha") or "").strip() or None
+        if head_sha and event_head_sha and event_head_sha != head_sha:
+            continue
+        latest_by_key[extracted["key"]] = extracted
+
+    checks = list(latest_by_key.values())
+    checks.sort(
+        key=lambda item: (
+            _ci_sort_rank(
+                str(item.get("conclusion") or ""), str(item.get("status") or "")
+            ),
+            str(item.get("name") or ""),
+        )
+    )
+    return [
+        {
+            "source": item["source"],
+            "name": item["name"],
+            "status": item["status"],
+            "conclusion": item["conclusion"],
+            "details_url": item["details_url"],
+            "head_sha": item["head_sha"],
+        }
+        for item in checks
+    ]
+
+
+def _extract_ci_check(
+    event_type: str, payload: dict[str, Any]
+) -> dict[str, Any] | None:
+    if event_type not in {"check_run", "check_suite", "workflow_run"}:
+        return None
+
+    nested = payload.get(event_type)
+    if not isinstance(nested, dict):
+        return None
+
+    check_id = nested.get("id")
+    name = _as_text(nested.get("name"))
+    if not name and event_type == "workflow_run":
+        name = _as_text(nested.get("display_title"))
+    if not name and event_type == "check_suite":
+        app_info = nested.get("app")
+        if isinstance(app_info, dict):
+            name = _as_text(app_info.get("name"))
+    if not name:
+        name = event_type.replace("_", " ")
+
+    return {
+        "key": f"{event_type}:{check_id or name}",
+        "source": event_type,
+        "name": name,
+        "status": _as_text(nested.get("status")) or "unknown",
+        "conclusion": _as_text(nested.get("conclusion")) or "unknown",
+        "details_url": _as_text(nested.get("details_url"))
+        or _as_text(nested.get("html_url")),
+        "head_sha": _as_text(nested.get("head_sha")),
+    }
+
+
+def _summarize_ci_status(ci_checks: list[dict[str, Any]]) -> str:
+    if any(_is_failed_ci_check(item) for item in ci_checks):
+        return "failed"
+    if any(_is_pending_ci_check(item) for item in ci_checks):
+        return "pending"
+    if ci_checks:
+        return "passed"
+    return "unknown"
+
+
+def _is_failed_ci_check(item: dict[str, Any]) -> bool:
+    conclusion = _as_text(item.get("conclusion")) or ""
+    return conclusion in {
+        "failure",
+        "cancelled",
+        "timed_out",
+        "action_required",
+        "startup_failure",
+        "stale",
+    }
+
+
+def _is_pending_ci_check(item: dict[str, Any]) -> bool:
+    status_value = _as_text(item.get("status")) or ""
+    if status_value and status_value != "completed":
+        return True
+    conclusion = _as_text(item.get("conclusion")) or ""
+    return conclusion in {"queued", "in_progress", "pending", "waiting", "requested"}
+
+
+def _ci_sort_rank(conclusion: str, status_value: str) -> int:
+    if conclusion in {
+        "failure",
+        "cancelled",
+        "timed_out",
+        "action_required",
+        "startup_failure",
+        "stale",
+    }:
+        return 0
+    if status_value and status_value != "completed":
+        return 1
+    return 2
 
 
 def _parse_row_payload(raw_payload_json: str) -> dict[str, Any] | None:
@@ -297,3 +443,11 @@ def _is_autofix_summary_comment(*, event_type: str, body: str | None) -> bool:
     if not isinstance(body, str):
         return False
     return _AUTOFIX_SUMMARY_COMMENT_PATTERN.search(body) is not None
+
+
+def _as_text(value: Any) -> str | None:
+    if isinstance(value, str):
+        text = value.strip()
+        if text:
+            return text
+    return None

--- a/app/schemas/normalizer.py
+++ b/app/schemas/normalizer.py
@@ -17,6 +17,17 @@ class IssueItem(BaseModel):
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
 
+class CICheckItem(BaseModel):
+    source: NonEmptyStr
+    name: NonEmptyStr
+    status: NonEmptyStr
+    conclusion: NonEmptyStr
+    details_url: str | None = None
+    head_sha: str | None = None
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
 class NormalizedReview(BaseModel):
     repo: NonEmptyStr
     pr_number: PositiveInt
@@ -25,6 +36,8 @@ class NormalizedReview(BaseModel):
     must_fix: list[IssueItem] = Field(default_factory=list)
     should_fix: list[IssueItem] = Field(default_factory=list)
     ignore: list[IssueItem] = Field(default_factory=list)
+    ci_status: NonEmptyStr | None = None
+    ci_checks: list[CICheckItem] = Field(default_factory=list)
     summary: str
 
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)

--- a/app/services/agent_prompt.py
+++ b/app/services/agent_prompt.py
@@ -16,9 +16,14 @@ def build_autofix_prompt(
     must_fix = _as_issue_list(normalized_review.get("must_fix"))
     should_fix = _as_issue_list(normalized_review.get("should_fix"))
     metadata = pr_metadata or {}
+    ci_checks = _as_ci_check_list(normalized_review.get("ci_checks"))
 
     must_fix_summary = _format_issue_summary("must_fix", must_fix)
     should_fix_summary = _format_issue_summary("should_fix", should_fix)
+    ci_summary = _format_ci_summary(
+        ci_status=_safe_text(normalized_review.get("ci_status"), "unknown"),
+        ci_checks=ci_checks,
+    )
 
     lines = [
         "You are an autofix agent working on a pull request.",
@@ -31,22 +36,24 @@ def build_autofix_prompt(
     _append_pr_metadata(lines, metadata)
     lines.extend(
         [
-            "",
-            "Hard constraints:",
-            "- Only fix issues explicitly listed in review feedback.",
-            "- Do not perform unrelated refactors.",
-            "- Do not expand the scope of changes beyond touched files/lines that are required for the listed issues.",
-            "- Prioritize passing existing tests before any optional improvement.",
-            "- If a required fix cannot be completed, output the reason and stop.",
-            "",
-            "Work items:",
-            must_fix_summary,
-            should_fix_summary,
-            "",
-            "Execution policy:",
-            "- Apply must_fix items first.",
-            "- Apply should_fix items only if they do not risk breaking tests.",
-            "- Keep patches minimal and directly traceable to review comments.",
+        ci_summary,
+        "",
+        "Hard constraints:",
+        "- Only fix issues explicitly listed in review feedback.",
+        "- Do not perform unrelated refactors.",
+        "- Do not expand the scope of changes beyond touched files/lines that are required for the listed issues.",
+        "- Prioritize passing existing tests before any optional improvement.",
+        "- If a required fix cannot be completed, output the reason and stop.",
+        "- Treat CI failures as supporting context, not as permission for unrelated changes.",
+        "",
+        "Work items:",
+        must_fix_summary,
+        should_fix_summary,
+        "",
+        "Execution policy:",
+        "- Apply must_fix items first.",
+        "- Apply should_fix items only if they do not risk breaking tests.",
+        "- Keep patches minimal and directly traceable to review comments.",
         ]
     )
     return "\n".join(lines)
@@ -119,6 +126,16 @@ def _as_issue_list(value: Any) -> list[Mapping[str, Any]]:
     return issue_items
 
 
+def _as_ci_check_list(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    check_items: list[Mapping[str, Any]] = []
+    for item in value:
+        if isinstance(item, Mapping):
+            check_items.append(item)
+    return check_items
+
+
 def _format_issue_summary(title: str, items: list[Mapping[str, Any]]) -> str:
     if not items:
         return f"- {title}: 0 items"
@@ -159,6 +176,23 @@ def _append_pr_metadata(lines: list[str], metadata: Mapping[str, Any]) -> None:
         if len(compact_body) > PR_BODY_PREVIEW_LIMIT:
             compact_body = f"{compact_body[:PR_BODY_PREVIEW_LIMIT].rstrip()}..."
         lines.append(f"- PR Body: {compact_body}")
+
+
+def _format_ci_summary(ci_status: str, ci_checks: list[Mapping[str, Any]]) -> str:
+    if not ci_checks:
+        return "- CI status: unknown (no CI checks captured)"
+
+    formatted_checks: list[str] = []
+    for item in ci_checks[:6]:
+        source = _safe_text(item.get("source"), "unknown")
+        name = _safe_text(item.get("name"), "unnamed")
+        status = _safe_text(item.get("status"), "unknown")
+        conclusion = _safe_text(item.get("conclusion"), "unknown")
+        formatted_checks.append(
+            f"[{source}] {name} => status={status}, conclusion={conclusion}"
+        )
+    joined = " | ".join(formatted_checks)
+    return f"- CI status: {ci_status} -> {joined}"
 
 
 def _safe_text(value: Any, fallback: str) -> str:

--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -61,6 +61,14 @@ BOOTSTRAP_STATE_DIRNAME = "software-factory"
 BOOTSTRAP_STATE_FILENAME = "bootstrap-state.json"
 LEGACY_BOOTSTRAP_STATE_FILENAME = ".software_factory_bootstrap_state.json"
 PR_FETCH_TIMEOUT_SECONDS = 30
+FAILED_CI_CONCLUSIONS = {
+    "failure",
+    "cancelled",
+    "timed_out",
+    "action_required",
+    "startup_failure",
+    "stale",
+}
 
 _REDACTION_PATTERNS = (
     re.compile(r"(ghp_[A-Za-z0-9]{16,})"),
@@ -479,6 +487,7 @@ def run_once(
                     repo=repo,
                     pr_number=pr_number,
                     prompt=prompt_for_attempt,
+                    normalized_review=payload,
                     modes=agent_modes,
                     openhands_command=feature_flags.openhands_command,
                     openhands_command_timeout_seconds=(
@@ -959,6 +968,7 @@ def _execute_agent_sdks(
     repo: str,
     pr_number: int,
     prompt: str,
+    normalized_review: Mapping[str, Any],
     modes: tuple[str, ...],
     openhands_command: str,
     openhands_command_timeout_seconds: int,
@@ -982,6 +992,7 @@ def _execute_agent_sdks(
                 "repo": repo,
                 "pr_number": pr_number,
                 "prompt": prompt,
+                "normalized_review": normalized_review,
                 "command": openhands_command,
                 "timeout_seconds": openhands_command_timeout_seconds,
             }
@@ -1020,6 +1031,7 @@ def _execute_agent_sdks(
                 claude_kwargs["on_log_line"] = on_log_line
             if should_cancel is not None:
                 claude_kwargs["should_cancel"] = should_cancel
+            claude_kwargs["normalized_review"] = normalized_review
             claude_ok, claude_message, claude_error_code = _run_claude_agent(
                 **claude_kwargs,
             )
@@ -1037,6 +1049,7 @@ def _run_openhands_agent(
     repo: str,
     pr_number: int,
     prompt: str,
+    normalized_review: Mapping[str, Any],
     *,
     command: str,
     timeout_seconds: int,
@@ -1049,6 +1062,7 @@ def _run_openhands_agent(
         repo=repo,
         pr_number=pr_number,
         prompt=prompt,
+        normalized_review=normalized_review,
         command=command,
         timeout_seconds=timeout_seconds,
         agent_name="OpenHands",
@@ -1064,6 +1078,7 @@ def _run_claude_agent(
     repo: str,
     pr_number: int,
     prompt: str,
+    normalized_review: Mapping[str, Any],
     *,
     command: str,
     provider: str,
@@ -1082,6 +1097,7 @@ def _run_claude_agent(
             repo=repo,
             pr_number=pr_number,
             prompt=prompt,
+            normalized_review=normalized_review,
             command=command,
             provider=provider,
             base_url=base_url,
@@ -1099,6 +1115,7 @@ def _run_claude_agent(
         repo=repo,
         pr_number=pr_number,
         prompt=prompt,
+        normalized_review=normalized_review,
         command=command,
         provider=provider,
         base_url=base_url,
@@ -1118,6 +1135,7 @@ def _run_claude_container_command(
     repo: str,
     pr_number: int,
     prompt: str,
+    normalized_review: Mapping[str, Any],
     command: str,
     provider: str,
     base_url: str,
@@ -1154,6 +1172,7 @@ def _run_claude_container_command(
         repo=repo,
         pr_number=pr_number,
         run_id=run_id,
+        normalized_review=normalized_review,
         provider=provider,
         base_url=base_url,
         model=model,
@@ -1191,6 +1210,7 @@ def _run_claude_stream_command(
     repo: str,
     pr_number: int,
     prompt: str,
+    normalized_review: Mapping[str, Any],
     command: str,
     provider: str,
     base_url: str,
@@ -1234,6 +1254,7 @@ def _run_claude_stream_command(
             repo=repo,
             pr_number=pr_number,
             run_id=run_id,
+            normalized_review=normalized_review,
             provider=provider,
             base_url=base_url,
             model=model,
@@ -1435,6 +1456,7 @@ def _build_claude_container_environment(
     repo: str,
     pr_number: int,
     run_id: int,
+    normalized_review: Mapping[str, Any],
     provider: str,
     base_url: str,
     model: str,
@@ -1443,6 +1465,7 @@ def _build_claude_container_environment(
         repo=repo,
         pr_number=pr_number,
         run_id=run_id,
+        normalized_review=normalized_review,
         provider=provider,
         base_url=base_url,
         model=model,
@@ -1490,6 +1513,7 @@ def _run_agent_command(
     repo: str,
     pr_number: int,
     prompt: str,
+    normalized_review: Mapping[str, Any],
     command: str,
     timeout_seconds: int,
     agent_name: str,
@@ -1525,7 +1549,12 @@ def _run_agent_command(
             stderr=subprocess.PIPE,
             stdin=subprocess.PIPE,
             text=True,
-            env=_build_agent_environment(repo=repo, pr_number=pr_number, run_id=run_id),
+            env=_build_agent_env(
+                run_id=run_id,
+                repo=repo,
+                pr_number=pr_number,
+                normalized_review=normalized_review,
+            ),
             start_new_session=True,
         )
     except FileNotFoundError:
@@ -1859,16 +1888,60 @@ def _build_agent_environment(
     return env
 
 
+def _build_agent_env(
+    *,
+    run_id: int,
+    repo: str,
+    pr_number: int,
+    normalized_review: Mapping[str, Any],
+) -> dict[str, str]:
+    env = _build_agent_environment(repo=repo, pr_number=pr_number, run_id=run_id)
+
+    ci_status, ci_checks = _extract_ci_context(normalized_review)
+    env["SOFTWARE_FACTORY_CI_STATUS"] = ci_status
+    env["SOFTWARE_FACTORY_CI_CHECKS_JSON"] = json.dumps(
+        ci_checks,
+        ensure_ascii=True,
+        sort_keys=True,
+    )
+    env["SOFTWARE_FACTORY_CI_FAILED_CHECKS"] = ", ".join(
+        str(item.get("name") or "").strip()
+        for item in ci_checks
+        if str(item.get("conclusion") or "").strip() in FAILED_CI_CONCLUSIONS
+        and str(item.get("name") or "").strip()
+    )
+    return env
+
+
+def _extract_ci_context(
+    normalized_review: Mapping[str, Any],
+) -> tuple[str, list[dict[str, Any]]]:
+    raw_checks = normalized_review.get("ci_checks")
+    ci_checks: list[dict[str, Any]] = []
+    if isinstance(raw_checks, list):
+        for item in raw_checks:
+            if isinstance(item, Mapping):
+                ci_checks.append(dict(item))
+    ci_status = _safe_text(normalized_review.get("ci_status")) or "unknown"
+    return ci_status, ci_checks
+
+
 def _build_claude_agent_environment(
     *,
     repo: str,
     pr_number: int,
     run_id: int,
+    normalized_review: Mapping[str, Any],
     provider: str,
     base_url: str,
     model: str,
 ) -> dict[str, str]:
-    env = _build_agent_environment(repo=repo, pr_number=pr_number, run_id=run_id)
+    env = _build_agent_env(
+        run_id=run_id,
+        repo=repo,
+        pr_number=pr_number,
+        normalized_review=normalized_review,
+    )
     normalized_provider = str(provider).strip().lower()
     normalized_base_url = str(base_url).strip()
     normalized_model = str(model).strip()

--- a/app/services/github_events.py
+++ b/app/services/github_events.py
@@ -11,6 +11,9 @@ SUPPORTED_EVENT_TYPES = {
     "pull_request_review",
     "pull_request_review_comment",
     "issue_comment",
+    "check_run",
+    "check_suite",
+    "workflow_run",
 }
 
 
@@ -125,6 +128,9 @@ def build_event_key(
         "review": payload.get("review"),
         "comment": payload.get("comment"),
         "issue": payload.get("issue"),
+        "check_run": payload.get("check_run"),
+        "check_suite": payload.get("check_suite"),
+        "workflow_run": payload.get("workflow_run"),
     }
     digest = hashlib.sha256(
         json.dumps(stable_fields, ensure_ascii=True, sort_keys=True).encode("utf-8")
@@ -185,6 +191,18 @@ def _extract_pr_number(event_type: str, payload: Mapping[str, Any]) -> int | Non
         if isinstance(issue, Mapping):
             return _as_int(issue.get("number"))
 
+    if event_type in {"check_run", "check_suite", "workflow_run"}:
+        nested = payload.get(event_type)
+        if isinstance(nested, Mapping):
+            pull_requests = nested.get("pull_requests")
+            if isinstance(pull_requests, list):
+                for item in pull_requests:
+                    if not isinstance(item, Mapping):
+                        continue
+                    number = _as_int(item.get("number"))
+                    if number is not None:
+                        return number
+
     return _as_int(payload.get("number"))
 
 
@@ -208,6 +226,13 @@ def _extract_head_sha(payload: Mapping[str, Any]) -> str | None:
         commit_id = _as_str(comment.get("commit_id"))
         if commit_id:
             return commit_id
+
+    for key in ("check_run", "check_suite", "workflow_run"):
+        nested = payload.get(key)
+        if isinstance(nested, Mapping):
+            sha = _as_str(nested.get("head_sha"))
+            if sha:
+                return sha
 
     return _as_str(payload.get("head_sha"))
 
@@ -236,6 +261,9 @@ def _extract_event_id(event_type: str, payload: Mapping[str, Any]) -> str | None
         "pull_request_review": "review",
         "pull_request_review_comment": "comment",
         "issue_comment": "comment",
+        "check_run": "check_run",
+        "check_suite": "check_suite",
+        "workflow_run": "workflow_run",
     }.get(event_type)
 
     if object_key:

--- a/tests/test_agent_prompt.py
+++ b/tests/test_agent_prompt.py
@@ -25,6 +25,15 @@ def test_build_autofix_prompt_contains_required_constraints_and_summaries() -> N
                 "text": "Consider improving message clarity",
             }
         ],
+        "ci_status": "failed",
+        "ci_checks": [
+            {
+                "source": "workflow_run",
+                "name": "CI / unit",
+                "status": "completed",
+                "conclusion": "failure",
+            }
+        ],
     }
 
     prompt = build_autofix_prompt(
@@ -41,6 +50,8 @@ def test_build_autofix_prompt_contains_required_constraints_and_summaries() -> N
     assert "output the reason and stop" in prompt
     assert "must_fix" in prompt
     assert "should_fix" in prompt
+    assert "CI status: failed" in prompt
+    assert "CI / unit" in prompt
     assert "acme/widgets" in prompt
     assert "#24" in prompt
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -12,6 +12,7 @@ from app.models import SCHEMA_SQL
 from app.services.agent_runner import (
     CHECK_COMMAND_TIMEOUT_SECONDS,
     RunnerOps,
+    _build_agent_env,
     _consume_claude_stream,
     _default_executor,
     _build_run_progress_callback,
@@ -968,6 +969,7 @@ def test_execute_agent_sdks_falls_back_to_claude(
         repo: str,
         pr_number: int,
         prompt: str,
+        normalized_review: dict[str, object],
         *,
         command: str,
         timeout_seconds: int,
@@ -983,6 +985,7 @@ def test_execute_agent_sdks_falls_back_to_claude(
         repo: str,
         pr_number: int,
         prompt: str,
+        normalized_review: dict[str, object],
         *,
         command: str,
         provider: str,
@@ -1006,6 +1009,7 @@ def test_execute_agent_sdks_falls_back_to_claude(
         repo="owner/repo",
         pr_number=1,
         prompt="fix this",
+        normalized_review={},
         modes=("openhands", "claude_agent_sdk"),
         openhands_command="openhands",
         openhands_command_timeout_seconds=600,
@@ -1035,6 +1039,7 @@ def test_execute_agent_sdks_does_not_fall_back_to_openhands_after_claude_failure
         repo: str,
         pr_number: int,
         prompt: str,
+        normalized_review: dict[str, object],
         *,
         command: str,
         provider: str,
@@ -1062,6 +1067,7 @@ def test_execute_agent_sdks_does_not_fall_back_to_openhands_after_claude_failure
         repo="owner/repo",
         pr_number=1,
         prompt="fix this",
+        normalized_review={},
         modes=("claude_agent_sdk", "openhands"),
         openhands_command="openhands",
         openhands_command_timeout_seconds=600,
@@ -1124,6 +1130,7 @@ def test_run_claude_agent_uses_normalized_command_and_filtered_env(
         repo="acme/widgets",
         pr_number=7,
         prompt="fix this",
+        normalized_review={},
         command="  claude --print  ",
         provider="openrouter",
         base_url="https://openrouter.ai/api",
@@ -1219,6 +1226,7 @@ def test_run_claude_agent_supports_docker_runtime(
         repo="acme/widgets",
         pr_number=7,
         prompt="fix this",
+        normalized_review={},
         command="claude",
         provider="openrouter",
         base_url="https://openrouter.ai/api",
@@ -1277,6 +1285,7 @@ def test_run_claude_agent_rejects_shell_control_tokens(tmp_path: Path) -> None:
         repo="acme/widgets",
         pr_number=7,
         prompt="fix this",
+        normalized_review={},
         command="claude && whoami",
         provider="openrouter",
         base_url="https://openrouter.ai/api",
@@ -1302,7 +1311,6 @@ def test_sanitize_log_text_redacts_tokens() -> None:
     assert "ghp_abcdefghijklmnopqrstuvwxyz" not in masked
     assert "test-openai-key" not in masked
     assert "[REDACTED]" in masked
-
 
 def test_render_claude_stream_record_handles_non_object_json() -> None:
     lines, result_text, error_text, saw_events = _render_claude_stream_record(
@@ -1380,3 +1388,39 @@ def test_build_run_progress_callback_updates_file_database_from_worker_thread(
     ).fetchone()
     assert row is not None
     assert row["logs_path"] == "logs/autofix-run-42.log"
+
+
+def test_build_agent_env_includes_ci_context() -> None:
+    env = _build_agent_env(
+        run_id=19,
+        repo="acme/widgets",
+        pr_number=24,
+        normalized_review={
+            "ci_status": "failed",
+            "ci_checks": [
+                {
+                    "source": "workflow_run",
+                    "name": "CI / unit",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "details_url": "https://example.test/runs/1",
+                    "head_sha": "abc123",
+                },
+                {
+                    "source": "check_run",
+                    "name": "lint",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "details_url": "https://example.test/runs/2",
+                    "head_sha": "abc123",
+                },
+            ],
+        },
+    )
+
+    assert env["SOFTWARE_FACTORY_REPO"] == "acme/widgets"
+    assert env["SOFTWARE_FACTORY_PR_NUMBER"] == "24"
+    assert env["SOFTWARE_FACTORY_RUN_ID"] == "19"
+    assert env["SOFTWARE_FACTORY_CI_STATUS"] == "failed"
+    assert env["SOFTWARE_FACTORY_CI_FAILED_CHECKS"] == "CI / unit"
+    assert '"name": "CI / unit"' in env["SOFTWARE_FACTORY_CI_CHECKS_JSON"]

--- a/tests/test_github_webhook_route.py
+++ b/tests/test_github_webhook_route.py
@@ -219,3 +219,74 @@ def test_autofix_limit_prevents_queueing_new_run(tmp_path: Path) -> None:
     assert response.json()["insert_status"] == "inserted"
     assert response.json()["queue_status"] == "autofix_limit_reached"
     assert response.json()["queued_run_id"] is None
+
+
+def test_check_run_event_is_recorded_without_queueing_and_enriches_next_run(
+    tmp_path: Path,
+) -> None:
+    _set_env(tmp_path, secret="")
+    db_path = tmp_path / "software_factory.db"
+
+    check_payload = {
+        "action": "completed",
+        "repository": {"full_name": "acme/widgets", "language": "Python"},
+        "check_run": {
+            "id": 9001,
+            "name": "CI / unit",
+            "status": "completed",
+            "conclusion": "failure",
+            "details_url": "https://example.test/runs/9001",
+            "head_sha": "abc123",
+            "pull_requests": [{"number": 42}],
+        },
+        "sender": {"login": "github-actions[bot]"},
+    }
+    review_payload = {
+        "repository": {"full_name": "acme/widgets", "language": "Python"},
+        "pull_request": {"number": 42, "head": {"sha": "abc123", "ref": "feature/x"}},
+        "review": {"id": 1001, "body": "Please fix the failing tests"},
+        "sender": {"login": "reviewer"},
+    }
+
+    with TestClient(app) as client:
+        check_response = client.post(
+            "/github/webhook",
+            json=check_payload,
+            headers={"X-GitHub-Event": "check_run"},
+        )
+        review_response = client.post(
+            "/github/webhook",
+            json=review_payload,
+            headers={"X-GitHub-Event": "pull_request_review"},
+        )
+
+    assert check_response.status_code == 200
+    assert check_response.json()["insert_status"] == "inserted"
+    assert check_response.json()["queue_status"] == "recorded"
+    assert check_response.json()["queued_run_id"] is None
+
+    assert review_response.status_code == 200
+    assert review_response.json()["queue_status"] == "queued"
+    run_id = review_response.json()["queued_run_id"]
+    assert isinstance(run_id, int)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT normalized_review_json FROM autofix_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+
+    assert row is not None
+    payload = json.loads(row["normalized_review_json"])
+    assert payload["ci_status"] == "failed"
+    assert payload["ci_checks"] == [
+        {
+            "source": "check_run",
+            "name": "CI / unit",
+            "status": "completed",
+            "conclusion": "failure",
+            "details_url": "https://example.test/runs/9001",
+            "head_sha": "abc123",
+        }
+    ]

--- a/tests/test_normalizer_schema.py
+++ b/tests/test_normalizer_schema.py
@@ -20,6 +20,17 @@ def test_normalized_review_valid_object() -> None:
         ],
         should_fix=[],
         ignore=[],
+        ci_status=" failed ",
+        ci_checks=[
+            {
+                "source": "workflow_run",
+                "name": "CI / unit",
+                "status": "completed",
+                "conclusion": "failure",
+                "details_url": " https://example.test/runs/1 ",
+                "head_sha": " abc123 ",
+            }
+        ],
         summary="  Needs one critical fix.  ",
     )
 
@@ -41,6 +52,17 @@ def test_normalized_review_valid_object() -> None:
         ],
         "should_fix": [],
         "ignore": [],
+        "ci_status": "failed",
+        "ci_checks": [
+            {
+                "source": "workflow_run",
+                "name": "CI / unit",
+                "status": "completed",
+                "conclusion": "failure",
+                "details_url": "https://example.test/runs/1",
+                "head_sha": "abc123",
+            }
+        ],
         "summary": "Needs one critical fix.",
     }
 


### PR DESCRIPTION
## Summary
- Added webhook support for check_suite/check_run/workflow_run events and normalized them into CI checks.
- Prevented CI webhook noise filtering so bot-sourced CI payloads are recorded but do not trigger queueing.
- Added CI status/check metadata to normalized payload, environment variables, and agent prompt context.
- Enriched queued autofix runs with latest CI check summaries and failed checks for better agent awareness.
- Updated tests for CI event recording, normalization schema, prompt output, and runner env handling.

## Validation
- pytest tests/test_agent_runner.py tests/test_agent_prompt.py tests/test_normalizer_schema.py tests/test_github_webhook_route.py
