### PR TITLE
fix: default background runtime to port 8001

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ python scripts/init_db.py
 4) 启动服务
 
 ```bash
-uvicorn app.main:app --host 127.0.0.1 --port 8000 --reload
+uvicorn app.main:app --host 127.0.0.1 --port 8001 --reload
 ```
 
 后台快速启动 `web + worker`：
@@ -189,22 +189,22 @@ chmod +x scripts/start_system_bg.sh
 
 常用页面：
 
-- `http://127.0.0.1:8000/`
-- `http://127.0.0.1:8000/runs`
-- `http://127.0.0.1:8000/runs/demo-run`
+- `http://127.0.0.1:8001/`
+- `http://127.0.0.1:8001/runs`
+- `http://127.0.0.1:8001/runs/demo-run`
 
 ## 开发与调试命令
 
 健康检查：
 
 ```bash
-curl -i http://127.0.0.1:8000/healthz
+curl -i http://127.0.0.1:8001/healthz
 ```
 
 模拟 Hook 事件（`/hook-events`）：
 
 ```bash
-curl -i -X POST http://127.0.0.1:8000/hook-events \
+curl -i -X POST http://127.0.0.1:8001/hook-events \
   -H 'content-type: application/json' \
   -d '{"event":"UserPromptSubmit","session_id":"sess_demo","repo":"owner/repo","branch":"feat/demo","cwd":"/tmp/software-factory","timestamp":"2026-03-12T12:00:00Z"}'
 ```
@@ -214,7 +214,7 @@ curl -i -X POST http://127.0.0.1:8000/hook-events \
 模拟 GitHub Webhook（`/github/webhook`）：
 
 ```bash
-curl -i -X POST http://127.0.0.1:8000/github/webhook \
+curl -i -X POST http://127.0.0.1:8001/github/webhook \
   -H 'content-type: application/json' \
   -H 'x-github-event: pull_request_review' \
   -d '{"action":"submitted","review":{"id":123},"pull_request":{"number":10}}'

--- a/example.env
+++ b/example.env
@@ -1,6 +1,6 @@
 APP_ENV=development
 HOST=0.0.0.0
-PORT=8000
+PORT=8001
 DB_PATH=./data/software_factory.db
 GITHUB_WEBHOOK_SECRET=
 MAX_AUTOFIX_PER_PR=3

--- a/scripts/start_system_bg.sh
+++ b/scripts/start_system_bg.sh
@@ -28,7 +28,7 @@ WEB_LOG_FILE="${LOG_DIR}/web.log"
 WORKER_LOG_FILE="${LOG_DIR}/worker.log"
 
 HOST="${HOST:-127.0.0.1}"
-PORT="${PORT:-8000}"
+PORT="${PORT:-8001}"
 DB_PATH="${DB_PATH:-${REPO_ROOT}/data/software_factory.db}"
 WORKSPACE_DIR="${WORKSPACE_DIR:-${REPO_ROOT}}"
 WORKER_INTERVAL_SECONDS="${WORKER_INTERVAL_SECONDS:-2}"
@@ -56,7 +56,7 @@ Environment overrides:
   LOAD_ENV_FILE=0            Skip sourcing ${REPO_ROOT}/.env
   PYTHON_BIN=/path/python    Python interpreter to use
   HOST=127.0.0.1             Web bind host
-  PORT=8000                  Web bind port
+  PORT=8001                  Web bind port
   DB_PATH=/path/app.db       Shared SQLite path for web and worker
   WORKSPACE_DIR=/path/repo   Worker runtime root
   WORKER_INTERVAL_SECONDS=2  Worker polling interval


### PR DESCRIPTION
## Summary
- change the background start script default port from `8000` to `8001`
- align `example.env` with the same default port
- update README examples and URLs to use port `8001`

## Testing
- bash -n scripts/start_system_bg.sh