### PR TITLE
feat: adapt open-swe github-only runner ideas

### DIFF
--- a/app/services/agent_prompt.py
+++ b/app/services/agent_prompt.py
@@ -4,6 +4,7 @@ from typing import Any, Mapping
 
 
 PR_BODY_PREVIEW_LIMIT = 600
+REPO_INSTRUCTIONS_PREVIEW_LIMIT = 4_000
 
 
 def build_autofix_prompt(
@@ -12,6 +13,7 @@ def build_autofix_prompt(
     head_sha: str,
     normalized_review: Mapping[str, Any],
     pr_metadata: Mapping[str, Any] | None = None,
+    repo_instructions: str | None = None,
 ) -> str:
     must_fix = _as_issue_list(normalized_review.get("must_fix"))
     should_fix = _as_issue_list(normalized_review.get("should_fix"))
@@ -34,6 +36,7 @@ def build_autofix_prompt(
         f"- Head SHA: {head_sha}",
     ]
     _append_pr_metadata(lines, metadata)
+    _append_repo_instructions(lines, repo_instructions)
     lines.extend(
         [
         ci_summary,
@@ -193,6 +196,21 @@ def _format_ci_summary(ci_status: str, ci_checks: list[Mapping[str, Any]]) -> st
         )
     joined = " | ".join(formatted_checks)
     return f"- CI status: {ci_status} -> {joined}"
+
+
+def _append_repo_instructions(lines: list[str], repo_instructions: str | None) -> None:
+    instructions = _safe_text(repo_instructions, "")
+    if not instructions:
+        return
+    compact = instructions.strip()
+    if len(compact) > REPO_INSTRUCTIONS_PREVIEW_LIMIT:
+        compact = f"{compact[:REPO_INSTRUCTIONS_PREVIEW_LIMIT].rstrip()}..."
+    lines.extend(
+        [
+            "- Repository Instructions (AGENTS.md):",
+            compact,
+        ]
+    )
 
 
 def _safe_text(value: Any, fallback: str) -> str:

--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -268,14 +268,6 @@ def run_once(
     pr_metadata = _collect_pull_request_metadata(repo=repo, pr_number=pr_number)
     head_sha = head_sha or _safe_text(pr_metadata.get("head_sha"))
     branch = branch or _safe_text(pr_metadata.get("head_ref"))
-
-    prompt = active_ops.build_autofix_prompt(
-        repo=repo,
-        pr_number=pr_number,
-        head_sha=head_sha or "unknown",
-        normalized_review=payload,
-        pr_metadata=pr_metadata,
-    )
     commands = active_ops.collect_check_commands(project_type)
     cleanup_archived_logs(
         base_dir=runtime_root,
@@ -332,9 +324,6 @@ def run_once(
         f"head_sha={head_sha or 'unknown'}",
         f"branch={branch or 'unknown'}",
         f"agent_modes={','.join(agent_modes)}",
-        "prompt:",
-        prompt,
-        "",
     ]
     logger = RunLogger(
         workspace_dir=runtime_root,
@@ -343,6 +332,41 @@ def run_once(
         on_progress=_build_run_progress_callback(conn, run_id),
     )
     update_run_logs_path(conn, run_id, logger.logs_path)
+
+    def _build_terminal_result(
+        *,
+        status: str,
+        error_summary: str | None,
+        logs_path: str,
+        commit_sha: str | None,
+        checks: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        final_error_summary, comment_posted = _post_run_comment_if_supported(
+            conn=conn,
+            run=run,
+            payload=payload,
+            active_ops=active_ops,
+            workspace_dir=runtime_root,
+            run_id=run_id,
+            repo=repo,
+            pr_number=pr_number,
+            status=status,
+            summary=checks,
+            commit_sha=commit_sha,
+            error_summary=error_summary,
+            logs_path=logs_path,
+            on_log_line=logger.append,
+        )
+        return {
+            "run_id": run_id,
+            "status": status,
+            "error_summary": final_error_summary,
+            "logs_path": logs_path,
+            "commit_sha": commit_sha,
+            "checks": dict(checks),
+            "comment_posted": comment_posted,
+        }
+
     lock_acquired = acquire_pr_lock(
         conn=conn,
         repo=repo,
@@ -361,20 +385,13 @@ def run_once(
             logs_path,
             error_code="pr_locked",
         )
-        return {
-            "run_id": run_id,
-            "status": status,
-            "error_summary": error_summary,
-            "logs_path": logs_path,
-            "commit_sha": None,
-            "checks": {
-                "overall_status": "failed",
-                "passed_count": 0,
-                "failed_count": 0,
-                "failed_commands": [],
-            },
-            "comment_posted": False,
-        }
+        return _build_terminal_result(
+            status=status,
+            error_summary=error_summary,
+            logs_path=logs_path,
+            commit_sha=None,
+            checks=checks_summary,
+        )
 
     if is_run_cancel_requested(conn, run_id):
         logger.append("cancel_requested: stopping run before execution")
@@ -384,15 +401,13 @@ def run_once(
             run_id,
             logs_path,
         )
-        return {
-            "run_id": run_id,
-            "status": status,
-            "error_summary": run_error_summary,
-            "logs_path": logs_path,
-            "commit_sha": None,
-            "checks": checks_summary,
-            "comment_posted": False,
-        }
+        return _build_terminal_result(
+            status=status,
+            error_summary=run_error_summary,
+            logs_path=logs_path,
+            commit_sha=None,
+            checks=checks_summary,
+        )
 
     agent_workspace = runtime_root
     agent_worktree: str | None = None
@@ -419,20 +434,24 @@ def run_once(
                     logs_path=logs_path,
                     error_code=OPENHANDS_FAILURE_CODE_WORKTREE,
                 )
-                return {
-                    "run_id": run_id,
-                    "status": status,
-                    "error_summary": scheduled_error,
-                    "logs_path": logs_path,
-                    "commit_sha": None,
-                    "checks": {
-                        "overall_status": "failed",
-                        "passed_count": 0,
-                        "failed_count": 0,
-                        "failed_commands": [],
-                    },
-                    "comment_posted": False,
-                }
+                return _build_terminal_result(
+                    status=status,
+                    error_summary=scheduled_error,
+                    logs_path=logs_path,
+                    commit_sha=None,
+                    checks=checks_summary,
+                )
+
+    repo_instructions = _read_repo_instructions(agent_workspace)
+    prompt = active_ops.build_autofix_prompt(
+        repo=repo,
+        pr_number=pr_number,
+        head_sha=head_sha or "unknown",
+        normalized_review=payload,
+        pr_metadata=pr_metadata,
+        repo_instructions=repo_instructions,
+    )
+    logger.extend(["prompt:", prompt, ""])
 
     try:
         status = "failed"
@@ -461,15 +480,13 @@ def run_once(
                 run_id,
                 logs_path,
             )
-            return {
-                "run_id": run_id,
-                "status": status,
-                "error_summary": run_error_summary,
-                "logs_path": logs_path,
-                "commit_sha": None,
-                "checks": checks_summary,
-                "comment_posted": False,
-            }
+            return _build_terminal_result(
+                status=status,
+                error_summary=run_error_summary,
+                logs_path=logs_path,
+                commit_sha=None,
+                checks=checks_summary,
+            )
         baseline_failure_index = _build_check_failure_index(baseline_check_results)
         if baseline_failure_index:
             logger.append(
@@ -522,15 +539,13 @@ def run_once(
                         run_id,
                         logs_path,
                     )
-                    return {
-                        "run_id": run_id,
-                        "status": status,
-                        "error_summary": run_error_summary,
-                        "logs_path": logs_path,
-                        "commit_sha": None,
-                        "checks": checks_summary,
-                        "comment_posted": False,
-                    }
+                    return _build_terminal_result(
+                        status=status,
+                        error_summary=run_error_summary,
+                        logs_path=logs_path,
+                        commit_sha=None,
+                        checks=checks_summary,
+                    )
                 failure_summary = (
                     f"{sdk_error_code}: {sdk_error_message}"
                     if sdk_error_code
@@ -546,20 +561,13 @@ def run_once(
                     logs_path=logs_path,
                     error_code=sdk_error_code or "agent_sdk_failed",
                 )
-                return {
-                    "run_id": run_id,
-                    "status": status,
-                    "error_summary": run_error_summary,
-                    "logs_path": logs_path,
-                    "commit_sha": None,
-                    "checks": {
-                        "overall_status": "failed",
-                        "passed_count": 0,
-                        "failed_count": 0,
-                        "failed_commands": [],
-                    },
-                    "comment_posted": False,
-                }
+                return _build_terminal_result(
+                    status=status,
+                    error_summary=run_error_summary,
+                    logs_path=logs_path,
+                    commit_sha=None,
+                    checks=checks_summary,
+                )
 
             try:
                 check_results, checks_summary = _run_validation_cycle(
@@ -580,15 +588,13 @@ def run_once(
                     run_id,
                     logs_path,
                 )
-                return {
-                    "run_id": run_id,
-                    "status": status,
-                    "error_summary": run_error_summary,
-                    "logs_path": logs_path,
-                    "commit_sha": None,
-                    "checks": checks_summary,
-                    "comment_posted": False,
-                }
+                return _build_terminal_result(
+                    status=status,
+                    error_summary=run_error_summary,
+                    logs_path=logs_path,
+                    commit_sha=None,
+                    checks=checks_summary,
+                )
             new_failure_results = _filter_new_check_failures(
                 baseline_check_results=baseline_check_results,
                 current_check_results=check_results,
@@ -674,52 +680,21 @@ def run_once(
         )
 
     if status == "retry_scheduled":
-        return {
-            "run_id": run_id,
-            "status": status,
-            "error_summary": run_error_summary,
-            "logs_path": logs_path,
-            "commit_sha": commit_sha,
-            "checks": checks_summary,
-            "comment_posted": False,
-        }
-
-    comment_body = _build_pr_comment(
-        run_id=run_id,
-        status=status,
-        summary=checks_summary,
-        commit_sha=commit_sha,
-        error_summary=run_error_summary,
-        logs_path=logs_path,
-    )
-    posted, comment_message = active_ops.post_pr_comment(
-        runtime_root,
-        repo,
-        pr_number,
-        comment_body,
-    )
-    if not posted:
-        comment_failure = f"pr_comment_failed: {comment_message}"
-        logger.append(comment_failure)
-        run_error_summary = _merge_error_summary(run_error_summary, comment_failure)
-        mark_run_finished(
-            conn=conn,
-            run_id=run_id,
+        return _build_terminal_result(
             status=status,
-            commit_sha=commit_sha,
             error_summary=run_error_summary,
             logs_path=logs_path,
+            commit_sha=commit_sha,
+            checks=checks_summary,
         )
 
-    return {
-        "run_id": run_id,
-        "status": status,
-        "error_summary": run_error_summary,
-        "logs_path": logs_path,
-        "commit_sha": commit_sha,
-        "checks": checks_summary,
-        "comment_posted": posted,
-    }
+    return _build_terminal_result(
+        status=status,
+        error_summary=run_error_summary,
+        logs_path=logs_path,
+        commit_sha=commit_sha,
+        checks=checks_summary,
+    )
 
 
 def _finalize_git_changes(
@@ -2455,6 +2430,86 @@ def _build_pr_comment(
         lines.append(f"Error: {error_summary}")
     lines.append(f"Logs: {logs_path}")
     return "\n".join(lines)
+
+
+def _read_repo_instructions(workspace_dir: str) -> str | None:
+    path = Path(workspace_dir) / "AGENTS.md"
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    normalized = content.strip()
+    return normalized or None
+
+
+def _post_run_comment_if_supported(
+    *,
+    conn: sqlite3.Connection,
+    run: Mapping[str, Any],
+    payload: Mapping[str, Any],
+    active_ops: RunnerOps,
+    workspace_dir: str,
+    run_id: int,
+    repo: str,
+    pr_number: int,
+    status: str,
+    summary: Mapping[str, Any],
+    commit_sha: str | None,
+    error_summary: str | None,
+    logs_path: str,
+    on_log_line: Callable[[str], None] | None = None,
+) -> tuple[str | None, bool]:
+    if not _should_post_run_comment(run=run, payload=payload, status=status):
+        return error_summary, False
+
+    comment_body = _build_pr_comment(
+        run_id=run_id,
+        status=status,
+        summary=summary,
+        commit_sha=commit_sha,
+        error_summary=error_summary,
+        logs_path=logs_path,
+    )
+    posted, comment_message = active_ops.post_pr_comment(
+        workspace_dir,
+        repo,
+        pr_number,
+        comment_body,
+    )
+    if posted:
+        return error_summary, True
+
+    comment_failure = f"pr_comment_failed: {comment_message}"
+    if on_log_line is not None:
+        on_log_line(comment_failure)
+    merged_error_summary = _merge_error_summary(error_summary, comment_failure)
+    mark_run_finished(
+        conn=conn,
+        run_id=run_id,
+        status=status,
+        commit_sha=commit_sha,
+        error_summary=merged_error_summary,
+        logs_path=logs_path,
+    )
+    return merged_error_summary, False
+
+
+def _should_post_run_comment(
+    *,
+    run: Mapping[str, Any],
+    payload: Mapping[str, Any],
+    status: str,
+) -> bool:
+    if status == "retry_scheduled":
+        return False
+    if _safe_text(run.get("trigger_source")) == "manual_issue":
+        return False
+    if _safe_text(payload.get("source_kind")) == "issue":
+        return False
+    pr_number = run.get("pr_number")
+    if not isinstance(pr_number, int):
+        return False
+    return pr_number > 0
 
 
 def _resolve_branch(

--- a/tests/test_agent_prompt.py
+++ b/tests/test_agent_prompt.py
@@ -90,6 +90,20 @@ def test_build_autofix_prompt_shows_positive_pr_stats() -> None:
     assert "- Diff Stats: +5 / -2" in prompt
 
 
+def test_build_autofix_prompt_includes_repo_instructions_when_present() -> None:
+    prompt = build_autofix_prompt(
+        repo="acme/widgets",
+        pr_number=24,
+        head_sha="abc123def",
+        normalized_review={},
+        repo_instructions="Do not edit generated files.\nRun pytest before finishing.",
+    )
+
+    assert "Repository Instructions (AGENTS.md)" in prompt
+    assert "Do not edit generated files." in prompt
+    assert "Run pytest before finishing." in prompt
+
+
 def test_collect_check_commands_defaults_to_python_commands() -> None:
     assert collect_check_commands() == [
         "python -m pytest -q",

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -247,6 +247,55 @@ def test_collect_pull_request_metadata_returns_empty_on_timeout(
     )
 
 
+def test_run_once_injects_repo_agents_md_into_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _make_conn()
+    run = _enqueue_and_claim(conn)
+    prompts: list[str] = []
+    (tmp_path / "AGENTS.md").write_text(
+        "Do not edit generated files.\nRun pytest before finishing.\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        agent_runner,
+        "_prepare_run_workspace",
+        lambda **kwargs: (str(tmp_path), None, "feature/test", "abc123"),
+    )
+
+    def fake_execute_agent_sdks(**kwargs):
+        prompts.append(str(kwargs["prompt"]))
+        return True, None, None, "claude_agent_sdk"
+
+    monkeypatch.setattr(agent_runner, "_execute_agent_sdks", fake_execute_agent_sdks)
+
+    result = run_once(
+        conn=conn,
+        run=run,
+        workspace_dir=str(tmp_path),
+        executor=lambda *_: {"returncode": 0, "stdout": "ok", "stderr": ""},
+        ops=RunnerOps(
+            commit_and_push=lambda **_: {
+                "success": True,
+                "commit_sha": "deadbeef",
+                "error": None,
+                "error_stage": None,
+                "remote": "origin",
+                "branch": "feature/test",
+                "pushed_ref": "origin/feature/test",
+            },
+            post_pr_comment=lambda *_: (True, "ok"),
+        ),
+    )
+
+    assert result["status"] == "success"
+    assert len(prompts) == 1
+    assert "Repository Instructions (AGENTS.md)" in prompts[0]
+    assert "Do not edit generated files." in prompts[0]
+
+
 def test_prepare_run_workspace_skips_pr_refetch_when_branch_and_head_known(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -820,6 +869,7 @@ def test_run_once_fails_when_agent_sdk_not_configured(
 ) -> None:
     conn = _make_conn()
     run = _enqueue_and_claim(conn)
+    posted_comments: list[str] = []
 
     ops = RunnerOps(
         checkout_branch=lambda *_: (True, "checked out"),
@@ -829,7 +879,10 @@ def test_run_once_fails_when_agent_sdk_not_configured(
             "commit_sha": "deadbeef",
             "error": None,
         },
-        post_pr_comment=lambda *_: (True, "ok"),
+        post_pr_comment=lambda *_args: (
+            posted_comments.append(str(_args[3])) or True,
+            "ok",
+        ),
     )
     monkeypatch.setattr(
         agent_runner,
@@ -852,6 +905,10 @@ def test_run_once_fails_when_agent_sdk_not_configured(
 
     assert result["status"] == "failed"
     assert "ai_not_configured" in str(result["error_summary"])
+    assert result["comment_posted"] is True
+    assert len(posted_comments) == 1
+    assert "Status: failed" in posted_comments[0]
+    assert "ai_not_configured" in posted_comments[0]
 
 
 def test_run_once_marks_agent_error_as_non_retryable(


### PR DESCRIPTION
## Summary
- inject repository AGENTS.md guidance into the autofix prompt after the run workspace is prepared
- route terminal PR-backed run outcomes through a shared comment fallback helper so several early-exit failures still post a run summary comment
- add targeted prompt and runner coverage for AGENTS.md injection and early failure comment fallback

## Testing
- python -m pytest tests/test_agent_prompt.py tests/test_agent_runner.py -q