### PR TITLE
fix: require mergeable PRs before run success

### DIFF
--- a/app/services/agent_prompt.py
+++ b/app/services/agent_prompt.py
@@ -177,6 +177,7 @@ def _append_pr_merge_state_context(
                 "⚠️ PR Conflict State:",
                 "- This pull request has merge conflicts with the base branch.",
                 "- Automatic merging is not possible until conflicts are resolved.",
+                "- Do not treat the run as complete until the PR is mergeable again.",
             ]
         )
         if can_be_rebased:
@@ -195,6 +196,7 @@ def _append_pr_merge_state_context(
                 "⚠️ PR Behind Base Branch:",
                 "- This pull request is behind the base branch.",
                 "- Consider updating the PR branch before applying fixes.",
+                "- The run is only complete once the PR is mergeable again.",
             ]
         )
         if can_be_rebased:

--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -71,6 +71,8 @@ FAILED_CI_CONCLUSIONS = {
     "startup_failure",
     "stale",
 }
+MERGEABILITY_RECHECK_ATTEMPTS = 3
+MERGEABILITY_RECHECK_DELAY_SECONDS = 2.0
 
 _REDACTION_PATTERNS = (
     re.compile(r"(ghp_[A-Za-z0-9]{16,})"),
@@ -713,6 +715,17 @@ def run_once(
                     log_lines=log_lines,
                 )
                 run_error_summary = git_error_summary
+                if status == "success":
+                    mergeability_error = _ensure_pr_is_mergeable_after_run(
+                        repo=repo,
+                        pr_number=pr_number,
+                        initial_metadata=pr_metadata,
+                        logger=logger,
+                    )
+                    if mergeability_error:
+                        status = "failed"
+                        run_error_summary = mergeability_error
+                        run_error_code = "pr_not_mergeable_after_run"
                 logger.flush()
                 break
 
@@ -2403,6 +2416,78 @@ def _collect_pull_request_metadata(*, repo: str, pr_number: int) -> dict[str, An
         "is_behind": is_behind,
         "is_blocked": is_blocked,
     }
+
+
+def _pr_requires_mergeability_gate(metadata: Mapping[str, Any] | None) -> bool:
+    if not metadata:
+        return False
+    if metadata.get("is_merge_conflict") or metadata.get("is_behind"):
+        return True
+    mergeable = metadata.get("mergeable")
+    if isinstance(mergeable, bool):
+        return not mergeable
+    mergeable_state = (_safe_text(mergeable) or "").upper()
+    return mergeable_state in {"CONFLICTING"}
+
+
+def _pr_mergeability_verdict(metadata: Mapping[str, Any] | None) -> str:
+    if not metadata:
+        return "unknown"
+    if metadata.get("is_merge_conflict") or metadata.get("is_behind"):
+        return "blocked"
+    mergeable = metadata.get("mergeable")
+    if isinstance(mergeable, bool):
+        return "mergeable" if mergeable else "blocked"
+    mergeable_state = (_safe_text(mergeable) or "").upper()
+    if mergeable_state == "MERGEABLE":
+        return "mergeable"
+    if mergeable_state == "CONFLICTING":
+        return "blocked"
+    merge_state_status = (_safe_text(metadata.get("merge_state_status")) or "").upper()
+    if merge_state_status in {"UNKNOWN", "UNSTABLE"}:
+        return "unknown"
+    return "unknown"
+
+
+def _format_pr_mergeability_status(metadata: Mapping[str, Any] | None) -> str:
+    if not metadata:
+        return "mergeability metadata unavailable"
+    merge_state_status = _safe_text(metadata.get("merge_state_status")) or "unknown"
+    mergeable = metadata.get("mergeable")
+    mergeable_text = str(mergeable) if mergeable is not None else "unknown"
+    return f"merge_state={merge_state_status} mergeable={mergeable_text}"
+
+
+def _ensure_pr_is_mergeable_after_run(
+    *,
+    repo: str,
+    pr_number: int,
+    initial_metadata: Mapping[str, Any] | None,
+    logger: RunLogger,
+) -> str | None:
+    latest_metadata: Mapping[str, Any] | None = None
+    gate_required = _pr_requires_mergeability_gate(initial_metadata)
+    for attempt in range(1, MERGEABILITY_RECHECK_ATTEMPTS + 1):
+        latest_metadata = _collect_pull_request_metadata(repo=repo, pr_number=pr_number)
+        gate_required = gate_required or _pr_requires_mergeability_gate(latest_metadata)
+        if not gate_required:
+            return None
+        verdict = _pr_mergeability_verdict(latest_metadata)
+        summary = _format_pr_mergeability_status(latest_metadata)
+        if verdict == "mergeable":
+            logger.append(f"pr_mergeability_verified: {summary}")
+            return None
+        if verdict == "unknown" and attempt < MERGEABILITY_RECHECK_ATTEMPTS:
+            logger.append(
+                f"pr_mergeability_recheck: attempt={attempt}/{MERGEABILITY_RECHECK_ATTEMPTS} {summary}"
+            )
+            time.sleep(MERGEABILITY_RECHECK_DELAY_SECONDS)
+            continue
+        logger.append(f"pr_mergeability_blocker: {summary}")
+        if verdict == "unknown":
+            return f"pr_mergeability_unverified: {summary}"
+        return f"pr_not_mergeable_after_run: {summary}"
+    return None
 
 
 def _run_git_command(

--- a/app/services/git_ops.py
+++ b/app/services/git_ops.py
@@ -40,6 +40,20 @@ def _pick_message(result: subprocess.CompletedProcess[str]) -> str:
     return f"git exited with code {result.returncode}"
 
 
+def _resolve_target_branch(
+    repo_dir: str, branch: str | None
+) -> tuple[str | None, str | None]:
+    if branch is not None:
+        return branch, None
+    branch_result = _run_git(repo_dir, ["rev-parse", "--abbrev-ref", "HEAD"])
+    if branch_result.returncode != 0:
+        return None, _pick_message(branch_result)
+    target_branch = branch_result.stdout.strip()
+    if not target_branch or target_branch == "HEAD":
+        return None, "detached_head"
+    return target_branch, None
+
+
 def ensure_head_sha(repo_dir: str, expected_sha: str) -> bool:
     result = _run_git(repo_dir, ["rev-parse", "HEAD"])
     if result.returncode != 0:
@@ -109,13 +123,69 @@ def commit_and_push(
 
     diff_result = _run_git(repo_dir, ["diff", "--cached", "--quiet"])
     if diff_result.returncode == 0:
+        target_branch, branch_error = _resolve_target_branch(repo_dir, branch)
+        if target_branch and not branch_error:
+            ahead_result = _run_git(
+                repo_dir,
+                ["rev-list", "--left-right", "--count", f"{remote}/{target_branch}...HEAD"],
+            )
+            if ahead_result.returncode == 0:
+                counts = ahead_result.stdout.strip().split()
+                if len(counts) == 2:
+                    try:
+                        ahead_count = int(counts[1])
+                    except ValueError:
+                        ahead_count = 0
+                    if ahead_count > 0:
+                        sha_result = _run_git(repo_dir, ["rev-parse", "HEAD"])
+                        if sha_result.returncode != 0:
+                            return {
+                                "success": False,
+                                "commit_sha": None,
+                                "error": _pick_message(sha_result),
+                                "error_stage": "git_rev_parse",
+                                "remote": remote,
+                                "branch": target_branch,
+                                "pushed_ref": None,
+                            }
+                        commit_sha = sha_result.stdout.strip()
+                        if not commit_sha:
+                            return {
+                                "success": False,
+                                "commit_sha": None,
+                                "error": "empty_commit_sha",
+                                "error_stage": "git_rev_parse",
+                                "remote": remote,
+                                "branch": target_branch,
+                                "pushed_ref": None,
+                            }
+                        push_result = _run_git(repo_dir, ["push", remote, target_branch])
+                        if push_result.returncode != 0:
+                            return {
+                                "success": False,
+                                "commit_sha": commit_sha,
+                                "error": _pick_message(push_result),
+                                "error_stage": "git_push",
+                                "remote": remote,
+                                "branch": target_branch,
+                                "pushed_ref": f"{remote}/{target_branch}",
+                            }
+                        return {
+                            "success": True,
+                            "commit_sha": commit_sha,
+                            "error": None,
+                            "error_stage": None,
+                            "remote": remote,
+                            "branch": target_branch,
+                            "pushed_ref": f"{remote}/{target_branch}",
+                        }
         return {
             "success": False,
             "commit_sha": None,
             "error": "no_changes",
             "error_stage": "git_diff",
             "remote": remote,
-            "branch": branch,
+            "branch": target_branch if target_branch else branch,
             "pushed_ref": None,
         }
     if diff_result.returncode != 1:
@@ -165,30 +235,17 @@ def commit_and_push(
             "pushed_ref": None,
         }
 
-    target_branch = branch
-    if target_branch is None:
-        branch_result = _run_git(repo_dir, ["rev-parse", "--abbrev-ref", "HEAD"])
-        if branch_result.returncode != 0:
-            return {
-                "success": False,
-                "commit_sha": commit_sha,
-                "error": _pick_message(branch_result),
-                "error_stage": "git_branch",
-                "remote": remote,
-                "branch": None,
-                "pushed_ref": None,
-            }
-        target_branch = branch_result.stdout.strip()
-        if not target_branch or target_branch == "HEAD":
-            return {
-                "success": False,
-                "commit_sha": commit_sha,
-                "error": "detached_head",
-                "error_stage": "git_branch",
-                "remote": remote,
-                "branch": target_branch or None,
-                "pushed_ref": None,
-            }
+    target_branch, branch_error = _resolve_target_branch(repo_dir, branch)
+    if branch_error or not target_branch:
+        return {
+            "success": False,
+            "commit_sha": commit_sha,
+            "error": branch_error or "detached_head",
+            "error_stage": "git_branch",
+            "remote": remote,
+            "branch": target_branch or None,
+            "pushed_ref": None,
+        }
 
     push_result = _run_git(repo_dir, ["push", remote, target_branch])
     if push_result.returncode != 0:

--- a/tests/test_agent_prompt.py
+++ b/tests/test_agent_prompt.py
@@ -232,6 +232,7 @@ def test_build_autofix_prompt_shows_merge_conflict_state() -> None:
     assert "⚠️ PR Conflict State:" in prompt
     assert "merge conflicts with the base branch" in prompt
     assert "Automatic merging is not possible" in prompt
+    assert "Do not treat the run as complete until the PR is mergeable again." in prompt
     assert "- Can Be Rebased: True" in prompt
     assert "- Mergeable: False" in prompt
 
@@ -254,6 +255,7 @@ def test_build_autofix_prompt_shows_behind_state() -> None:
     assert "- Merge State: BEHIND" in prompt
     assert "⚠️ PR Behind Base Branch:" in prompt
     assert "behind the base branch" in prompt
+    assert "The run is only complete once the PR is mergeable again." in prompt
     assert "- Can Be Rebased: True" in prompt
 
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -1960,14 +1960,30 @@ def test_run_once_rebases_when_pr_is_behind(
     run = _enqueue_and_claim(conn)
     (tmp_path / "AGENTS.md").write_text("# Instructions", encoding="utf-8")
 
+    metadata_calls = 0
+
     def fake_pr_metadata(repo, pr_number):
+        nonlocal metadata_calls
+        metadata_calls += 1
+        if metadata_calls == 1:
+            return {
+                "title": "Behind PR",
+                "base_ref": "main",
+                "head_ref": "feature/test",
+                "head_sha": "abc123",
+                "is_merge_conflict": False,
+                "is_behind": True,
+                "can_be_rebased": True,
+            }
         return {
             "title": "Behind PR",
             "base_ref": "main",
             "head_ref": "feature/test",
-            "head_sha": "abc123",
+            "head_sha": "newsha123",
+            "merge_state_status": "MERGEABLE",
+            "mergeable": "MERGEABLE",
             "is_merge_conflict": False,
-            "is_behind": True,
+            "is_behind": False,
             "can_be_rebased": True,
         }
 
@@ -2032,13 +2048,29 @@ def test_run_once_rebases_when_pr_has_merge_conflict(
     run = _enqueue_and_claim(conn)
     (tmp_path / "AGENTS.md").write_text("# Instructions", encoding="utf-8")
 
+    metadata_calls = 0
+
     def fake_pr_metadata(repo, pr_number):
+        nonlocal metadata_calls
+        metadata_calls += 1
+        if metadata_calls == 1:
+            return {
+                "title": "Conflict PR",
+                "base_ref": "main",
+                "head_ref": "feature/test",
+                "head_sha": "abc123",
+                "is_merge_conflict": True,
+                "is_behind": False,
+                "can_be_rebased": True,
+            }
         return {
             "title": "Conflict PR",
             "base_ref": "main",
             "head_ref": "feature/test",
-            "head_sha": "abc123",
-            "is_merge_conflict": True,
+            "head_sha": "newsha123",
+            "merge_state_status": "MERGEABLE",
+            "mergeable": "MERGEABLE",
+            "is_merge_conflict": False,
             "is_behind": False,
             "can_be_rebased": True,
         }
@@ -2093,6 +2125,94 @@ def test_run_once_rebases_when_pr_has_merge_conflict(
 
     assert result["status"] == "success"
     assert len(rebase_calls) == 1
+
+
+def test_run_once_fails_when_pr_still_not_mergeable_after_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _make_conn()
+    run = _enqueue_and_claim(conn)
+    (tmp_path / "AGENTS.md").write_text("# Instructions", encoding="utf-8")
+
+    metadata_calls = 0
+
+    def fake_pr_metadata(repo, pr_number):
+        nonlocal metadata_calls
+        metadata_calls += 1
+        if metadata_calls == 1:
+            return {
+                "title": "Conflict PR",
+                "base_ref": "main",
+                "head_ref": "feature/test",
+                "head_sha": "abc123",
+                "merge_state_status": "DIRTY",
+                "mergeable": "CONFLICTING",
+                "is_merge_conflict": True,
+                "is_behind": False,
+                "can_be_rebased": True,
+            }
+        return {
+            "title": "Conflict PR",
+            "base_ref": "main",
+            "head_ref": "feature/test",
+            "head_sha": "newsha123",
+            "merge_state_status": "DIRTY",
+            "mergeable": "CONFLICTING",
+            "is_merge_conflict": True,
+            "is_behind": False,
+            "can_be_rebased": True,
+        }
+
+    def fake_rebase(repo_dir, base_ref, remote):
+        return (True, "rebased onto origin/main", False)
+
+    def fake_run_git_command(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0] if args else [], returncode=0, stdout="newsha123\n", stderr=""
+        )
+
+    monkeypatch.setattr(
+        agent_runner, "_collect_pull_request_metadata", fake_pr_metadata
+    )
+    monkeypatch.setattr(
+        agent_runner,
+        "_prepare_run_workspace",
+        lambda **kwargs: (str(tmp_path), str(tmp_path), "feature/test", "abc123"),
+    )
+    monkeypatch.setattr(
+        agent_runner,
+        "_execute_agent_sdks",
+        lambda **kwargs: (True, None, None, "claude_agent_sdk"),
+    )
+    monkeypatch.setattr(agent_runner, "_run_git_command", fake_run_git_command)
+
+    ops = RunnerOps(
+        commit_and_push=lambda **_: {
+            "success": True,
+            "commit_sha": "deadbeef",
+            "error": None,
+            "error_stage": None,
+            "remote": "origin",
+            "branch": "feature/test",
+            "pushed_ref": "origin/feature/test",
+        },
+        post_pr_comment=lambda *_: (True, "ok"),
+        rebase_onto_base=fake_rebase,
+    )
+
+    result = run_once(
+        conn=conn,
+        run=run,
+        workspace_dir=str(tmp_path),
+        executor=lambda *_: {"returncode": 0, "stdout": "ok", "stderr": ""},
+        ops=ops,
+    )
+
+    assert result["status"] == "retry_scheduled"
+    assert "pr_not_mergeable_after_run" in (result["error_summary"] or "")
+    logs_text = Path(result["logs_path"]).read_text(encoding="utf-8")
+    assert "pr_mergeability_blocker: merge_state=DIRTY mergeable=CONFLICTING" in logs_text
 
 
 def test_run_once_blocks_on_rebase_conflict(

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -140,6 +140,20 @@ def test_commit_and_push_returns_no_changes(monkeypatch) -> None:
                 ["git", "diff", "--cached", "--quiet"],
                 _cp(["git", "diff", "--cached", "--quiet"], returncode=0),
             ),
+            (
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                _cp(
+                    ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                    stdout="feature/m5\n",
+                ),
+            ),
+            (
+                ["git", "rev-list", "--left-right", "--count", "origin/feature/m5...HEAD"],
+                _cp(
+                    ["git", "rev-list", "--left-right", "--count", "origin/feature/m5...HEAD"],
+                    stdout="0\t0\n",
+                ),
+            ),
         ],
     )
 
@@ -150,7 +164,7 @@ def test_commit_and_push_returns_no_changes(monkeypatch) -> None:
         "error": "no_changes",
         "error_stage": "git_diff",
         "remote": "origin",
-        "branch": None,
+        "branch": "feature/m5",
         "pushed_ref": None,
     }
     assert calls == [
@@ -164,7 +178,77 @@ def test_commit_and_push_returns_no_changes(monkeypatch) -> None:
             ".software_factory_bootstrap_state.json",
         ],
         ["git", "diff", "--cached", "--quiet"],
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        ["git", "rev-list", "--left-right", "--count", "origin/feature/m5...HEAD"],
     ]
+
+
+def test_commit_and_push_pushes_rebase_only_branch_head(monkeypatch) -> None:
+    calls = _patch_run(
+        monkeypatch,
+        [
+            (["git", "add", "-A"], _cp(["git", "add", "-A"])),
+            (
+                [
+                    "git",
+                    "diff",
+                    "--cached",
+                    "--name-only",
+                    "--",
+                    ".software_factory_bootstrap_state.json",
+                ],
+                _cp(
+                    [
+                        "git",
+                        "diff",
+                        "--cached",
+                        "--name-only",
+                        "--",
+                        ".software_factory_bootstrap_state.json",
+                    ]
+                ),
+            ),
+            (
+                ["git", "diff", "--cached", "--quiet"],
+                _cp(["git", "diff", "--cached", "--quiet"], returncode=0),
+            ),
+            (
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                _cp(
+                    ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                    stdout="feature/m5\n",
+                ),
+            ),
+            (
+                ["git", "rev-list", "--left-right", "--count", "origin/feature/m5...HEAD"],
+                _cp(
+                    ["git", "rev-list", "--left-right", "--count", "origin/feature/m5...HEAD"],
+                    stdout="0\t1\n",
+                ),
+            ),
+            (
+                ["git", "rev-parse", "HEAD"],
+                _cp(["git", "rev-parse", "HEAD"], stdout="deadbeef\n"),
+            ),
+            (
+                ["git", "push", "origin", "feature/m5"],
+                _cp(["git", "push", "origin", "feature/m5"]),
+            ),
+        ],
+    )
+
+    result = git_ops.commit_and_push("/repo", "msg")
+
+    assert result == {
+        "success": True,
+        "commit_sha": "deadbeef",
+        "error": None,
+        "error_stage": None,
+        "remote": "origin",
+        "branch": "feature/m5",
+        "pushed_ref": "origin/feature/m5",
+    }
+    assert calls[-1] == ["git", "push", "origin", "feature/m5"]
 
 
 def test_commit_and_push_success_infers_current_branch(monkeypatch) -> None:
@@ -346,6 +430,20 @@ def test_commit_and_push_excludes_runtime_state_file(monkeypatch) -> None:
             (
                 ["git", "diff", "--cached", "--quiet"],
                 _cp(["git", "diff", "--cached", "--quiet"], returncode=0),
+            ),
+            (
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                _cp(
+                    ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                    stdout="feature/m5\n",
+                ),
+            ),
+            (
+                ["git", "rev-list", "--left-right", "--count", "origin/feature/m5...HEAD"],
+                _cp(
+                    ["git", "rev-list", "--left-right", "--count", "origin/feature/m5...HEAD"],
+                    stdout="0\t0\n",
+                ),
             ),
         ],
     )


### PR DESCRIPTION
## Summary
- treat mergeability as a completion gate for PR autofix runs instead of only a prompt hint
- push rebase-only branch head updates even when there is no staged diff
- fail or retry runs that still leave the PR conflicted/behind after execution

## Testing
- python -m pytest tests/test_agent_prompt.py tests/test_git_ops.py tests/test_agent_runner.py -q