### PR TITLE
ci: run pytest on GitHub-hosted runner

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Switch the `Pytest` GitHub Actions workflow from a self-hosted runner to a GitHub-hosted runner.

## Change

- Update `.github/workflows/pytest.yml` from `runs-on: [self-hosted, Linux, X64]` to `runs-on: ubuntu-latest`

## Verification

- `git diff --check`
