### PR TITLE
Fix agent stall fallback and non-interactive OpenHands runs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,7 @@ class Settings(BaseSettings):
         "ai_not_configured",
         "ai_invalid_response",
         "ai_request_client_error",
+        "agent_claude_stalled",
         "patch_apply_failed",
         "rebase_conflict_blocker",
         "rebase_blocker",

--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -58,7 +58,9 @@ CLAUDE_AGENT_MODE = "claude_agent_sdk"
 OPENHANDS_FAILURE_CODE_WORKTREE = "agent_worktree_failed"
 OPENHANDS_FAILURE_CODE_COMMAND = "agent_openhands_failed"
 CLAUDE_FAILURE_CODE_COMMAND = "agent_claude_failed"
+CLAUDE_FAILURE_CODE_STALL = "agent_claude_stalled"
 RUN_CANCELLED_CODE = "cancelled"
+CLAUDE_PROGRESS_STALL_TIMEOUT_SECONDS = 120
 BOOTSTRAP_STATE_DIRNAME = "software-factory"
 BOOTSTRAP_STATE_FILENAME = "bootstrap-state.json"
 LEGACY_BOOTSTRAP_STATE_FILENAME = ".software_factory_bootstrap_state.json"
@@ -1075,6 +1077,7 @@ def _execute_agent_sdks(
 ) -> tuple[bool, str | None, str | None, str | None]:
     last_error_code: str | None = None
     last_error_message: str | None = None
+    last_mode: str | None = None
     for mode in modes:
         if mode == OPENHANDS_AGENT_MODE:
             openhands_kwargs: dict[str, Any] = {
@@ -1099,8 +1102,12 @@ def _execute_agent_sdks(
             if openhands_ok:
                 return True, None, None, OPENHANDS_AGENT_MODE
 
+            if openhands_error_code == RUN_CANCELLED_CODE:
+                return False, openhands_error_code, openhands_message, OPENHANDS_AGENT_MODE
+
             last_error_code = openhands_error_code
             last_error_message = openhands_message
+            last_mode = OPENHANDS_AGENT_MODE
             continue
 
         if mode == CLAUDE_AGENT_MODE:
@@ -1129,9 +1136,15 @@ def _execute_agent_sdks(
             if claude_ok:
                 return True, None, None, CLAUDE_AGENT_MODE
 
-            return False, claude_error_code, claude_message, CLAUDE_AGENT_MODE
+            if claude_error_code == RUN_CANCELLED_CODE:
+                return False, claude_error_code, claude_message, CLAUDE_AGENT_MODE
 
-    return False, last_error_code, last_error_message, None
+            last_error_code = claude_error_code
+            last_error_message = claude_message
+            last_mode = CLAUDE_AGENT_MODE
+            continue
+
+    return False, last_error_code, last_error_message, last_mode
 
 
 def _run_openhands_agent(
@@ -1160,6 +1173,8 @@ def _run_openhands_agent(
         failure_code=OPENHANDS_FAILURE_CODE_COMMAND,
         on_log_line=on_log_line,
         should_cancel=should_cancel,
+        argv_builder=_build_openhands_command_argv,
+        prompt_via_stdin=False,
     )
 
 
@@ -1389,6 +1404,7 @@ def _run_claude_stream_subprocess(
         "last_event_type": None,
         "last_event_subtype": None,
         "session_id": None,
+        "last_progress_at": time.monotonic(),
     }
     _register_active_agent_process(process.pid)
     stdout_chunks: list[str] = []
@@ -1440,13 +1456,17 @@ def _run_claude_stream_subprocess(
     )
     stderr_thread = threading.Thread(
         target=_consume_process_stream,
-        args=(stderr_stream, "stderr", stderr_chunks, on_log_line),
+        args=(stderr_stream, "stderr", stderr_chunks, on_log_line, state),
         daemon=True,
     )
     stdout_thread.start()
     stderr_thread.start()
     try:
         deadline = time.monotonic() + timeout_seconds
+        stall_timeout_seconds = min(
+            max(1, int(timeout_seconds)),
+            CLAUDE_PROGRESS_STALL_TIMEOUT_SECONDS,
+        )
         while True:
             if should_cancel is not None and should_cancel():
                 if on_log_line is not None:
@@ -1465,6 +1485,18 @@ def _run_claude_stream_subprocess(
                     False,
                     f"{agent_name} command timed out after {timeout_seconds}s",
                     failure_code,
+                )
+            last_progress_at = float(state.get("last_progress_at") or 0.0)
+            if time.monotonic() - last_progress_at >= stall_timeout_seconds:
+                if on_log_line is not None:
+                    on_log_line(
+                        f"[agent] no progress for {stall_timeout_seconds}s; terminating process"
+                    )
+                _terminate_agent_process_tree(process)
+                return (
+                    False,
+                    f"{agent_name} command stalled for {stall_timeout_seconds}s without progress",
+                    CLAUDE_FAILURE_CODE_STALL,
                 )
             time.sleep(1.0)
     except OSError as exc:
@@ -1591,6 +1623,23 @@ def _format_command_for_log(argv: list[str]) -> str:
     return _sanitize_log_text(" ".join(shlex.quote(token) for token in argv))
 
 
+def _build_openhands_command_argv(argv: list[str], prompt: str) -> list[str]:
+    expanded = list(argv)
+    if "--headless" not in expanded:
+        expanded.append("--headless")
+    if "--json" not in expanded:
+        expanded.append("--json")
+    has_task_or_file = any(
+        token in {"-t", "--task", "-f", "--file"} for token in expanded
+    ) or any(
+        token.startswith("--task=") or token.startswith("--file=")
+        for token in expanded
+    )
+    if prompt and not has_task_or_file:
+        expanded.extend(["--task", prompt])
+    return expanded
+
+
 def _build_claude_stream_command_argv(argv: list[str]) -> list[str]:
     expanded = list(argv)
     if "-p" not in expanded and "--print" not in expanded:
@@ -1631,6 +1680,8 @@ def _run_agent_command(
     failure_code: str,
     on_log_line: Callable[[str], None] | None = None,
     should_cancel: Callable[[], bool] | None = None,
+    argv_builder: Callable[[list[str], str], list[str]] | None = None,
+    prompt_via_stdin: bool = True,
 ) -> tuple[bool, str, str | None]:
     normalized_command = command.strip()
     if not normalized_command:
@@ -1650,6 +1701,8 @@ def _run_agent_command(
         )
     if not _command_exists(argv[0]):
         return False, f"{agent_name} command not found: {argv[0]}", failure_code
+    if argv_builder is not None:
+        argv = argv_builder(argv, prompt)
 
     process: subprocess.Popen[str]
     try:
@@ -1658,7 +1711,7 @@ def _run_agent_command(
             cwd=workspace,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            stdin=subprocess.PIPE,
+            stdin=subprocess.PIPE if prompt_via_stdin else subprocess.DEVNULL,
             text=True,
             env=_build_agent_env(
                 run_id=run_id,
@@ -1681,7 +1734,9 @@ def _run_agent_command(
     stdout_chunks: list[str] = []
     stderr_chunks: list[str] = []
     if on_log_line is not None:
-        on_log_line(f"[agent] starting {agent_name}: {normalized_command}")
+        on_log_line(
+            f"[agent] starting {agent_name}: {_format_command_for_log(argv)}"
+        )
     stdout_thread = threading.Thread(
         target=_consume_process_stream,
         args=(process.stdout, "stdout", stdout_chunks, on_log_line),
@@ -1695,7 +1750,7 @@ def _run_agent_command(
     stdout_thread.start()
     stderr_thread.start()
     try:
-        if process.stdin is not None:
+        if prompt_via_stdin and process.stdin is not None:
             process.stdin.write(prompt)
             process.stdin.close()
         deadline = time.monotonic() + timeout_seconds
@@ -1743,12 +1798,15 @@ def _consume_process_stream(
     stream_name: str,
     chunks: list[str],
     on_log_line: Callable[[str], None] | None,
+    state: dict[str, Any] | None = None,
 ) -> None:
     if stream is None:
         return
     try:
         for raw_line in iter(stream.readline, ""):
             chunks.append(raw_line)
+            if state is not None:
+                state["last_progress_at"] = time.monotonic()
             rendered = _clean_terminal_log_line(raw_line.rstrip("\n"))
             if on_log_line is not None and rendered:
                 on_log_line(f"[agent][{stream_name}] {rendered}")
@@ -1767,6 +1825,7 @@ def _consume_claude_stream(
     try:
         for raw_line in iter(stream.readline, ""):
             chunks.append(raw_line)
+            state["last_progress_at"] = time.monotonic()
             _update_claude_stream_state(raw_line, state)
             try:
                 rendered_lines, result_text, error_text, saw_events = (

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -1466,14 +1466,60 @@ def test_run_once_marks_agent_error_as_non_retryable(
     )
 
     assert result["status"] == "failed"
+
+
+def test_run_once_marks_claude_stall_as_non_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _make_conn()
+    run = _enqueue_and_claim(conn)
+
+    ops = RunnerOps(
+        checkout_branch=lambda *_: (True, "checked out"),
+        ensure_head_sha=lambda *_: True,
+        commit_and_push=lambda **_: {
+            "success": True,
+            "commit_sha": "deadbeef",
+            "error": None,
+        },
+        post_pr_comment=lambda *_: (True, "ok"),
+    )
+    monkeypatch.setattr(
+        agent_runner,
+        "_execute_agent_sdks",
+        lambda **kwargs: (
+            False,
+            agent_runner.CLAUDE_FAILURE_CODE_STALL,
+            "Claude Agent SDK command stalled for 120s without progress",
+            None,
+        ),
+    )
+
+    result = run_once(
+        conn=conn,
+        run=run,
+        workspace_dir=str(tmp_path),
+        executor=lambda *_: {"returncode": 0, "stdout": "ok", "stderr": ""},
+        ops=ops,
+    )
+
+    row = conn.execute(
+        "SELECT status, last_error_code FROM autofix_runs WHERE id = ?",
+        (run["id"],),
+    ).fetchone()
+    assert result["status"] == "failed"
+    assert row is not None
+    assert row["status"] == "failed"
+    assert row["last_error_code"] == agent_runner.CLAUDE_FAILURE_CODE_STALL
     row = conn.execute(
         "SELECT status, last_error_code, error_summary FROM autofix_runs WHERE id = ?",
         (run["id"],),
     ).fetchone()
     assert row is not None
     assert row["status"] == "failed"
-    assert row["last_error_code"] == "ai_request_client_error"
-    assert "ai_request_client_error" in str(result["error_summary"])
+    assert row["last_error_code"] == agent_runner.CLAUDE_FAILURE_CODE_STALL
+    assert agent_runner.CLAUDE_FAILURE_CODE_STALL in str(result["error_summary"])
 
 
 def test_run_once_schedules_retry_for_retryable_agent_error(
@@ -1609,7 +1655,7 @@ def test_execute_agent_sdks_falls_back_to_claude(
     assert calls == ["/tmp", "/tmp"]
 
 
-def test_execute_agent_sdks_does_not_fall_back_to_openhands_after_claude_failure(
+def test_execute_agent_sdks_falls_back_to_openhands_after_claude_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[str] = []
@@ -1661,9 +1707,51 @@ def test_execute_agent_sdks_does_not_fall_back_to_openhands_after_claude_failure
         claude_agent_command_timeout_seconds=600,
     )
 
+    assert ok is True
+    assert err_code is None
+    assert err_message is None
+    assert selected_mode == "openhands"
+    assert calls == ["claude", "openhands"]
+
+
+def test_execute_agent_sdks_stops_immediately_on_cancelled_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_claude(**kwargs) -> tuple[bool, str, str | None]:
+        calls.append("claude")
+        return False, "cancelled", agent_runner.RUN_CANCELLED_CODE
+
+    def fake_openhands(**kwargs) -> tuple[bool, str, str | None]:
+        calls.append("openhands")
+        return True, "openhands succeeded", None
+
+    monkeypatch.setattr(agent_runner, "_run_claude_agent", fake_claude)
+    monkeypatch.setattr(agent_runner, "_run_openhands_agent", fake_openhands)
+
+    ok, err_code, err_message, selected_mode = agent_runner._execute_agent_sdks(
+        workspace="/tmp",
+        run_id=123,
+        repo="owner/repo",
+        pr_number=1,
+        prompt="fix this",
+        normalized_review={},
+        modes=("claude_agent_sdk", "openhands"),
+        openhands_command="openhands",
+        openhands_command_timeout_seconds=600,
+        claude_agent_command="claude",
+        claude_agent_provider="openrouter",
+        claude_agent_base_url="https://openrouter.ai/api",
+        claude_agent_model="openrouter/hunter-alpha",
+        claude_agent_runtime="host",
+        claude_agent_container_image="",
+        claude_agent_command_timeout_seconds=600,
+    )
+
     assert ok is False
-    assert err_code == "agent_claude_failed"
-    assert err_message == "claude failed"
+    assert err_code == agent_runner.RUN_CANCELLED_CODE
+    assert err_message == "cancelled"
     assert selected_mode == "claude_agent_sdk"
     assert calls == ["claude"]
 
@@ -1758,6 +1846,125 @@ def test_run_claude_agent_uses_normalized_command_and_filtered_env(
     assert env["SOFTWARE_FACTORY_PR_NUMBER"] == "7"
     assert env["SOFTWARE_FACTORY_RUN_ID"] == "9"
     assert "UNRELATED_SECRET" not in env
+
+
+def test_build_openhands_command_argv_enables_headless_json_task() -> None:
+    argv = agent_runner._build_openhands_command_argv(["openhands"], "fix this")
+    assert argv == ["openhands", "--headless", "--json", "--task", "fix this"]
+
+    existing = agent_runner._build_openhands_command_argv(
+        ["openhands", "--headless", "--json", "--task", "existing"],
+        "ignored",
+    )
+    assert existing == ["openhands", "--headless", "--json", "--task", "existing"]
+
+
+def test_run_openhands_agent_uses_headless_task_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeProcess:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.returncode = 0
+            self.pid = 321
+            self.stdout = None
+            self.stderr = None
+            captured["command"] = (
+                list(args[0]) if args and isinstance(args[0], (list, tuple)) else []
+            )
+            captured.update(kwargs)
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+    monkeypatch.setenv("PATH", os.environ.get("PATH", ""))
+    monkeypatch.setattr(agent_runner.shutil, "which", lambda value: f"/usr/bin/{value}")
+    monkeypatch.setattr(agent_runner.subprocess, "Popen", _FakeProcess)
+
+    ok, message, error_code = agent_runner._run_openhands_agent(
+        workspace=str(tmp_path),
+        run_id=9,
+        repo="acme/widgets",
+        pr_number=7,
+        prompt="fix this",
+        normalized_review={},
+        command="openhands",
+        timeout_seconds=42,
+    )
+
+    assert ok is True
+    assert message == "OpenHands completed"
+    assert error_code is None
+    assert captured["command"] == [
+        "openhands",
+        "--headless",
+        "--json",
+        "--task",
+        "fix this",
+    ]
+    assert captured["stdin"] == agent_runner.subprocess.DEVNULL
+
+
+def test_run_claude_stream_subprocess_fails_on_stall(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    terminated: list[int] = []
+
+    class _EmptyStream:
+        def readline(self) -> str:
+            return ""
+
+        def close(self) -> None:
+            return None
+
+    class _FakeProcess:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.pid = 456
+            self.returncode = None
+            self.stdout = _EmptyStream()
+            self.stderr = _EmptyStream()
+
+        def poll(self) -> int | None:
+            return None
+
+    class _FakeThread:
+        def __init__(self, target: Any, args: tuple[Any, ...], daemon: bool = False) -> None:
+            self._target = target
+            self._args = args
+
+        def start(self) -> None:
+            self._target(*self._args)
+
+        def join(self, timeout: float | None = None) -> None:
+            return None
+
+    ticks = iter([0.0, 0.0, 121.0, 121.0])
+    monkeypatch.setattr(agent_runner.subprocess, "Popen", _FakeProcess)
+    monkeypatch.setattr(agent_runner.threading, "Thread", _FakeThread)
+    monkeypatch.setattr(agent_runner.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(agent_runner.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        agent_runner,
+        "_terminate_agent_process_tree",
+        lambda process: terminated.append(process.pid),
+    )
+
+    ok, message, error_code = agent_runner._run_claude_stream_subprocess(
+        workspace=str(tmp_path),
+        argv=["claude", "--print", "fix this"],
+        display_argv=["claude", "--print"],
+        timeout_seconds=600,
+        agent_name="Claude Agent SDK",
+        failure_code=agent_runner.CLAUDE_FAILURE_CODE_COMMAND,
+    )
+
+    assert ok is False
+    assert error_code == agent_runner.CLAUDE_FAILURE_CODE_STALL
+    assert "stalled" in message
+    assert terminated == [456]
 
 
 def test_run_claude_agent_supports_docker_runtime(


### PR DESCRIPTION
## Summary
- add a Claude no-progress stall timeout and treat it as a non-retryable failure code
- fall back to the next configured agent mode instead of aborting immediately after a Claude failure
- run OpenHands in explicit headless JSON task mode so worker-triggered runs stay non-interactive

## Testing
- python -m pytest tests/test_agent_runner.py tests/test_retry.py -q
- python -m pytest tests/test_web_settings.py -q
- python -m pytest tests/test_issue_submission.py -q