### PR TITLE
fix: harden opencode review workflow

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,7 +1,7 @@
 name: OpenCode PR Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
@@ -16,11 +16,11 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - name: Checkout repository
+      - name: Checkout trusted base revision
         uses: actions/checkout@v4
         with:
-          persist-credentials: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
 
       - name: Prepare OpenCode cache paths
         run: |


### PR DESCRIPTION
## Summary
- switch the review workflow to `pull_request_target` so secrets and write permissions stay on the trusted base workflow context
- checkout the PR base SHA instead of the PR head so the job does not execute untrusted scripts from the submitted branch
- disable credential persistence during checkout to avoid leaving a writable token in the workspace

## Verification
- validated `.github/workflows/opencode-review.yml` parses successfully with `python -c \"import yaml; yaml.safe_load(...)\"`