### PR TITLE
fix: restore opencode review pull_request trigger

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,13 +1,13 @@
 name: OpenCode PR Review
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   review:
     name: AI Code Review
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- switch the OpenCode review workflow back to `pull_request` because `opencode github run` does not support `pull_request_target`
- keep the trusted base checkout and disabled credential persistence from the earlier hardening change
- skip forked PRs so the review job only runs where repository secrets are expected and safe to use

## Verification
- validated `.github/workflows/opencode-review.yml` parses successfully with `python -c \"import yaml; yaml.safe_load(...)\"`
- confirmed the failing GitHub Actions run reports `Unsupported event type: pull_request_target`