### PR TITLE
docs: add repo link to LLM install prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,17 @@ env DB_PATH="$DB_PATH" python scripts/run_worker.py --loop --workspace-dir "$(pw
 
 ### LLM-Friendly Install Prompt
 
-Copy this into Codex / Claude / OpenCode when you want an agent to install and verify the project locally:
+Copy this into Codex / Claude / OpenCode when you want an agent to install and verify the project locally. Repository: `https://github.com/sun-praise/software-factory`
 
 ```text
-Install and verify this repository locally.
+Install and verify the GitHub repository https://github.com/sun-praise/software-factory locally.
+
+Repository bootstrap:
+- If the current workspace is not already the repository root for sun-praise/software-factory, clone or open this exact repository first.
+- If needed, run: git clone https://github.com/sun-praise/software-factory.git && cd software-factory
 
 Requirements:
+- Work from the repository root for sun-praise/software-factory.
 - Follow README.md and docs/local-runtime.md exactly.
 - Use Python 3.11+ and install dependencies from requirements.txt in a virtual environment.
 - Copy example.env to .env if needed.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,12 +159,17 @@ env DB_PATH="$DB_PATH" python scripts/run_worker.py --loop --workspace-dir "$(pw
 
 ### 面向 LLM 的安装 Prompt
 
-当你想让 Codex / Claude / OpenCode 帮你本地安装并验证项目时，可以直接复制下面这段：
+当你想让 Codex / Claude / OpenCode 帮你本地安装并验证项目时，可以直接复制下面这段。仓库地址：`https://github.com/sun-praise/software-factory`
 
 ```text
-Install and verify this repository locally.
+Install and verify the GitHub repository https://github.com/sun-praise/software-factory locally.
+
+Repository bootstrap:
+- If the current workspace is not already the repository root for sun-praise/software-factory, clone or open this exact repository first.
+- If needed, run: git clone https://github.com/sun-praise/software-factory.git && cd software-factory
 
 Requirements:
+- Work from the repository root for sun-praise/software-factory.
 - Follow README.md and docs/local-runtime.md exactly.
 - Use Python 3.11+ and install dependencies from requirements.txt in a virtual environment.
 - Copy example.env to .env if needed.


### PR DESCRIPTION
Closes #143

## Summary
- add the repository URL next to the LLM-friendly install prompt in both README files
- tell agents to clone or open the exact repository before running install steps
- require running from the repository root so OpenCode/Codex/Claude can install the right project directly

## Testing
- not run (README-only change)