### PR TITLE
docs: shorten LLM install prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,29 +165,14 @@ env DB_PATH="$DB_PATH" python scripts/run_worker.py --loop --workspace-dir "$(pw
 
 ### LLM-Friendly Install Prompt
 
-Copy this into Codex / Claude / OpenCode when you want an agent to install and verify the project locally. Repository: `https://github.com/sun-praise/software-factory`
+Copy this into Codex / Claude / OpenCode when you want an agent to install and verify the project locally. The detailed install steps now live in [docs/agent-install.md](docs/agent-install.md). Repository: `https://github.com/sun-praise/software-factory`
 
 ```text
 Install and verify the GitHub repository https://github.com/sun-praise/software-factory locally.
-
-Repository bootstrap:
-- If the current workspace is not already the repository root for sun-praise/software-factory, clone or open this exact repository first.
-- If needed, run: git clone https://github.com/sun-praise/software-factory.git && cd software-factory
-
-Requirements:
-- Work from the repository root for sun-praise/software-factory.
-- Follow README.md and docs/local-runtime.md exactly.
-- Use Python 3.11+ and install dependencies from requirements.txt in a virtual environment.
-- Copy example.env to .env if needed.
-- Choose one writable DB_PATH and use the exact same DB_PATH for every local process.
-- Do not let the web service use ./data/software_factory.db while the worker uses a different database.
-- Initialize the SQLite database with python scripts/init_db.py.
-- Start the web service on port 8001.
-- If you start the worker, it must use the same DB_PATH as the web service.
-- Verify the setup with curl -i http://127.0.0.1:8001/healthz.
-- If both web and worker are running, verify that both processes expose the same DB_PATH.
-- Do not modify application code just to make local setup pass. Only change local env/config when needed.
-- If something fails, report the exact failing command, the root cause, and the smallest fix.
+If the repository is not already open, clone or open it first.
+Then work from the repository root and follow docs/agent-install.md and docs/local-runtime.md exactly.
+Do not modify application code just to make local setup pass.
+If something fails, report the exact failing command, the root cause, and the smallest fix.
 ```
 
 ## Local Run

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,29 +159,14 @@ env DB_PATH="$DB_PATH" python scripts/run_worker.py --loop --workspace-dir "$(pw
 
 ### 面向 LLM 的安装 Prompt
 
-当你想让 Codex / Claude / OpenCode 帮你本地安装并验证项目时，可以直接复制下面这段。仓库地址：`https://github.com/sun-praise/software-factory`
+当你想让 Codex / Claude / OpenCode 帮你本地安装并验证项目时，可以直接复制下面这段。详细安装步骤现在放在仓库内的 [docs/agent-install.md](docs/agent-install.md)。仓库地址：`https://github.com/sun-praise/software-factory`
 
 ```text
 Install and verify the GitHub repository https://github.com/sun-praise/software-factory locally.
-
-Repository bootstrap:
-- If the current workspace is not already the repository root for sun-praise/software-factory, clone or open this exact repository first.
-- If needed, run: git clone https://github.com/sun-praise/software-factory.git && cd software-factory
-
-Requirements:
-- Work from the repository root for sun-praise/software-factory.
-- Follow README.md and docs/local-runtime.md exactly.
-- Use Python 3.11+ and install dependencies from requirements.txt in a virtual environment.
-- Copy example.env to .env if needed.
-- Choose one writable DB_PATH and use the exact same DB_PATH for every local process.
-- Do not let the web service use ./data/software_factory.db while the worker uses a different database.
-- Initialize the SQLite database with python scripts/init_db.py.
-- Start the web service on port 8001.
-- If you start the worker, it must use the same DB_PATH as the web service.
-- Verify the setup with curl -i http://127.0.0.1:8001/healthz.
-- If both web and worker are running, verify that both processes expose the same DB_PATH.
-- Do not modify application code just to make local setup pass. Only change local env/config when needed.
-- If something fails, report the exact failing command, the root cause, and the smallest fix.
+If the repository is not already open, clone or open it first.
+Then work from the repository root and follow docs/agent-install.md and docs/local-runtime.md exactly.
+Do not modify application code just to make local setup pass.
+If something fails, report the exact failing command, the root cause, and the smallest fix.
 ```
 
 ## 本地运行

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -1,0 +1,83 @@
+# Agent Install Guide
+
+Use this guide when an AI agent needs to install and verify `software-factory` locally.
+
+## Scope
+
+- Work from the repository root.
+- Follow this file and [docs/local-runtime.md](local-runtime.md) exactly.
+- If `docs/local-runtime.md` is more specific about `DB_PATH`, treat it as the source of truth.
+
+## Repository bootstrap
+
+If the current workspace is not already this repository:
+
+```bash
+git clone https://github.com/sun-praise/software-factory.git
+cd software-factory
+```
+
+## Required outcome
+
+- Install dependencies in a Python virtual environment
+- Initialize the SQLite database
+- Start the web service on port `8001`
+- If starting the worker, use the exact same `DB_PATH` as the web service
+- Verify the setup with `curl -i http://127.0.0.1:8001/healthz`
+
+## Steps
+
+1. Create a virtual environment and install dependencies.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install -r requirements.txt
+```
+
+2. Create local environment config.
+
+```bash
+cp example.env .env
+```
+
+3. Choose one writable `DB_PATH` and use that exact same value for every local process.
+
+```bash
+export DB_PATH="$(pwd)/data/software_factory.db"
+```
+
+4. Initialize the database.
+
+```bash
+python scripts/init_db.py
+```
+
+5. Start the web service on port `8001`.
+
+```bash
+env DB_PATH="$DB_PATH" uvicorn app.main:app --host 127.0.0.1 --port 8001 --reload
+```
+
+6. Optionally start the worker with the same `DB_PATH`.
+
+```bash
+env DB_PATH="$DB_PATH" python scripts/run_worker.py --loop --workspace-dir "$(pwd)"
+```
+
+7. Verify the web service.
+
+```bash
+curl -i http://127.0.0.1:8001/healthz
+```
+
+8. If both web and worker are running, verify that both processes expose the same `DB_PATH`.
+
+See [docs/local-runtime.md](local-runtime.md) for the exact process-level checks and the failure mode.
+
+## Guardrails
+
+- Do not modify application code just to make local setup pass.
+- Only change local env or config when needed.
+- If something fails, report the exact failing command, the root cause, and the smallest fix.


### PR DESCRIPTION
Closes #144

## Summary
- shorten the README install prompt so external AI tools only need the repo URL and repo-local doc entrypoint
- add docs/agent-install.md to hold the full install and verification procedure
- keep the DB_PATH and verification rules delegated to repo docs instead of the long README block

## Testing
- not run (README/docs-only change)