### PR TITLE
fix: run manual-issue checks from detected project root

### DIFF
--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -143,6 +143,20 @@ _DISALLOWED_COMMAND_TOKENS = {"&", "&&", ";", "<", "<<", ">", ">>", "|", "||"}
 _ACTIVE_AGENT_PIDS_LOCK = threading.Lock()
 _ACTIVE_AGENT_PIDS: set[int] = set()
 logger = logging.getLogger(__name__)
+_PYTHON_PROJECT_MARKERS = (
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "requirements.txt",
+)
+_PROJECT_ROOT_IGNORED_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "node_modules",
+    "__pycache__",
+}
 
 
 def _noop(*_args: Any, **_kwargs: Any) -> Any:
@@ -470,6 +484,9 @@ def run_once(
                 commit_sha=None,
                 checks=checks_summary,
             )
+    project_workspace = _resolve_project_workspace(agent_workspace, project_type)
+    if project_workspace != agent_workspace:
+        logger.append(f"project_workspace={project_workspace}")
 
     base_ref = _safe_text(pr_metadata.get("base_ref"))
     is_merge_conflict = pr_metadata.get("is_merge_conflict")
@@ -556,8 +573,8 @@ def run_once(
         status = "failed"
         run_error_code: str | None = None
         commit_sha: str | None = None
-        check_workspace = runtime_root
-        baseline_check_workspace = agent_workspace
+        check_workspace = project_workspace
+        baseline_check_workspace = project_workspace
         try:
             baseline_check_results, baseline_checks_summary = _run_validation_cycle(
                 conn=conn,
@@ -640,7 +657,7 @@ def run_once(
                 )
             )
             if used_agent_mode in {OPENHANDS_AGENT_MODE, CLAUDE_AGENT_MODE}:
-                check_workspace = agent_workspace
+                check_workspace = project_workspace
             logger.append(f"agent_mode={used_agent_mode or 'unknown'}")
             if sdk_error_message:
                 logger.append(f"agent_error: {sdk_error_message}")
@@ -2447,6 +2464,54 @@ def _prepare_run_workspace(
         )
 
     return run_workspace_dir, run_workspace_dir, resolved_branch, resolved_head_sha
+
+
+def _resolve_project_workspace(workspace_dir: str, project_type: str | None) -> str:
+    root = Path(workspace_dir).resolve()
+    normalized_type = (project_type or "").strip().lower()
+    if normalized_type != "python":
+        return str(root)
+    if _directory_has_any_marker(root, _PYTHON_PROJECT_MARKERS):
+        return str(root)
+    candidates = _find_nested_project_roots(
+        root,
+        markers=_PYTHON_PROJECT_MARKERS,
+        max_depth=3,
+    )
+    if len(candidates) == 1:
+        return str(candidates[0])
+    return str(root)
+
+
+def _directory_has_any_marker(directory: Path, markers: tuple[str, ...]) -> bool:
+    return any((directory / marker).is_file() for marker in markers)
+
+
+def _find_nested_project_roots(
+    root: Path,
+    *,
+    markers: tuple[str, ...],
+    max_depth: int,
+) -> list[Path]:
+    candidates: set[Path] = set()
+    for marker in markers:
+        for marker_path in root.rglob(marker):
+            parent = marker_path.parent.resolve()
+            if parent == root:
+                continue
+            try:
+                relative = parent.relative_to(root)
+            except ValueError:
+                continue
+            parts = relative.parts
+            if not parts:
+                continue
+            if any(part in _PROJECT_ROOT_IGNORED_DIRS for part in parts):
+                continue
+            if len(parts) > max_depth:
+                continue
+            candidates.add(parent)
+    return sorted(candidates, key=lambda item: (len(item.relative_to(root).parts), str(item)))
 
 
 def _ensure_repo_cache(

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -243,6 +243,94 @@ def test_run_once_failure_marks_failed_and_records_error(
     assert "ruff check" in str(row["error_summary"])
 
 
+def test_resolve_project_workspace_prefers_single_nested_python_project(
+    tmp_path: Path,
+) -> None:
+    nested = tmp_path / "latex-agent"
+    nested.mkdir()
+    (nested / "pyproject.toml").write_text("[project]\nname='latex-agent'\n", encoding="utf-8")
+    (tmp_path / "test_cost_calc.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+
+    resolved = agent_runner._resolve_project_workspace(str(tmp_path), "python")
+
+    assert resolved == str(nested)
+
+
+def test_resolve_project_workspace_keeps_root_when_root_is_python_project(
+    tmp_path: Path,
+) -> None:
+    nested = tmp_path / "latex-agent"
+    nested.mkdir()
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='workspace-root'\n", encoding="utf-8")
+    (nested / "pyproject.toml").write_text("[project]\nname='latex-agent'\n", encoding="utf-8")
+
+    resolved = agent_runner._resolve_project_workspace(str(tmp_path), "python")
+
+    assert resolved == str(tmp_path)
+
+
+def test_run_once_executes_checks_in_detected_project_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _make_conn()
+    run = _enqueue_manual_issue_and_claim(conn)
+    nested = tmp_path / "latex-agent"
+    nested.mkdir()
+    (nested / "pyproject.toml").write_text("[project]\nname='latex-agent'\n", encoding="utf-8")
+    (tmp_path / "test_cost_calc.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+    executed_workspaces: list[str] = []
+
+    def executor(command: str, workspace_dir: str) -> dict[str, object]:
+        executed_workspaces.append(workspace_dir)
+        return {
+            "returncode": 0,
+            "stdout": f"ok: {command} @ {workspace_dir}",
+            "stderr": "",
+        }
+
+    ops = RunnerOps(
+        checkout_branch=lambda *_: (True, "checked out"),
+        ensure_head_sha=lambda *_: True,
+        commit_and_push=lambda **_: {
+            "success": True,
+            "commit_sha": "deadbeef",
+            "error": None,
+            "error_stage": None,
+            "remote": "origin",
+            "branch": "autofix/run-1-issue-42",
+            "pushed_ref": "origin/autofix/run-1-issue-42",
+        },
+        post_pr_comment=lambda *_: (True, "ok"),
+        collect_check_commands=lambda *_: ["python -m pytest -q"],
+    )
+    monkeypatch.setattr(
+        agent_runner,
+        "_execute_agent_sdks",
+        lambda **kwargs: (True, None, None, "openhands"),
+    )
+    monkeypatch.setattr(
+        agent_runner,
+        "_bootstrap_workspace_runtime",
+        lambda workspace_dir, **kwargs: agent_runner.WorkspaceBootstrapResult(
+            ok=True,
+            skipped=True,
+        ),
+    )
+
+    result = run_once(
+        conn=conn,
+        run=run,
+        workspace_dir=str(tmp_path),
+        executor=executor,
+        ops=ops,
+    )
+
+    assert result["status"] == "success"
+    assert executed_workspaces
+    assert set(executed_workspaces) == {str(nested)}
+
+
 def test_run_once_fails_fast_for_manual_issue_without_context(tmp_path: Path) -> None:
     conn = _make_conn()
     enqueue_autofix_run(


### PR DESCRIPTION
Closes #148

## Summary
- detect a nested Python project root when the repo root is only a multi-project workspace shell
- run baseline and post-agent checks from the detected project directory instead of always using the repo root
- add regression coverage for project root detection and manual-issue check execution

## Testing
- python -m pytest -q tests/test_agent_runner.py -k "project_workspace or executes_checks_in_detected_project_workspace or prepare_run_workspace"
- python -m pytest -q tests/test_agent_runner.py -k "run_once or prepare_run_workspace"