### PR TITLE
fix: support issue_comment events and oauth token auth

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     port: int = 8000
     db_path: str = "./data/software_factory.db"
     github_webhook_secret: str = ""
+    github_token: str = ""
     github_webhook_debounce_seconds: int = 60
     max_autofix_per_pr: int = 3
     max_concurrent_runs: int = 3

--- a/app/routes/github.py
+++ b/app/routes/github.py
@@ -35,6 +35,7 @@ router = APIRouter(prefix="/github", tags=["github"])
 _REVIEW_EVENTS_ALLOWING_BOT_ACTORS = {
     "pull_request_review",
     "pull_request_review_comment",
+    "issue_comment",
 }
 _AUTOFIX_SUMMARY_COMMENT_PATTERN = re.compile(r"^\s*autofix run #\d+\b", re.IGNORECASE)
 
@@ -106,6 +107,9 @@ async def github_webhook(request: Request) -> dict[str, Any]:
             "reason": "unsupported_or_non_pr_event",
             "signature": signature_result.status,
         }
+
+    if not event.head_sha and event.repo and event.pr_number:
+        event, payload = _fill_pr_info_from_api(event, payload)
 
     should_ignore_actor = event_type in _REVIEW_EVENTS_ALLOWING_BOT_ACTORS
     event_body = extract_event_body(event_type, payload)
@@ -451,3 +455,37 @@ def _as_text(value: Any) -> str | None:
         if text:
             return text
     return None
+
+
+def _fill_pr_info_from_api(event, payload):
+    """issue_comment 事件不含 head_sha/branch，通过 GitHub API 补获取。"""
+    import dataclasses
+    import logging
+    import urllib.request
+
+    log = logging.getLogger("webhook_debug")
+    token = get_settings().github_token
+    if not token:
+        log.warning("GITHUB_TOKEN not set, cannot fetch PR info for %s#%s",
+                     event.repo, event.pr_number)
+        return event, payload
+
+    url = f"https://api.github.com/repos/{event.repo}/pulls/{event.pr_number}"
+    req = urllib.request.Request(url, headers={
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+    })
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            pr_data = json.loads(resp.read().decode("utf-8"))
+        head_sha = pr_data.get("head", {}).get("sha")
+        if head_sha:
+            log.info("Fetched head_sha=%s branch=%s for %s PR#%s",
+                     head_sha, pr_data.get("head", {}).get("ref"),
+                     event.repo, event.pr_number)
+            event = dataclasses.replace(event, head_sha=head_sha)
+            payload = dict(payload)
+            payload["pull_request"] = pr_data
+    except Exception as exc:
+        log.warning("Failed to fetch PR info from GitHub API: %s", exc)
+    return event, payload

--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -229,7 +229,7 @@ def run_once(
 ) -> dict[str, Any]:
     settings = get_settings()
     active_ops = ops or RunnerOps()
-    runtime_root = _validate_runtime_root(workspace_dir)
+    runtime_root = _resolve_repo_workspace(workspace_dir, run.get("repo"))
     run_id = int(run["id"])
     repo = str(run.get("repo") or "")
     pr_number = int(run.get("pr_number") or 0)
@@ -2265,12 +2265,11 @@ def _terminate_agent_process_tree_by_pid(pid: int) -> None:
 def _build_agent_environment(
     *, repo: str, pr_number: int, run_id: int
 ) -> dict[str, str]:
-    env = {
-        key: value
-        for key, value in os.environ.items()
-        if key in _ALLOWED_AGENT_ENV_KEYS
-        or any(key.startswith(prefix) for prefix in _ALLOWED_AGENT_ENV_PREFIXES)
-    }
+    # 继承完整环境，确保 node/claude 需要的所有系统变量都在
+    env = dict(os.environ)
+    # 移除空值的 ANTHROPIC_API_KEY，避免覆盖 OAuth 认证
+    if not env.get("ANTHROPIC_API_KEY", "").strip():
+        env.pop("ANTHROPIC_API_KEY", None)
     env["SOFTWARE_FACTORY_REPO"] = repo
     env["SOFTWARE_FACTORY_PR_NUMBER"] = str(pr_number)
     env["SOFTWARE_FACTORY_RUN_ID"] = str(run_id)
@@ -2352,7 +2351,7 @@ def _build_claude_agent_environment(
         if deepseek_key:
             env["ANTHROPIC_AUTH_TOKEN"] = deepseek_key
             env["ANTHROPIC_API_KEY"] = deepseek_key
-    else:
+    elif normalized_provider:
         openrouter_key = str(os.environ.get("OPENROUTER_API_KEY", "")).strip()
         if openrouter_key:
             env["ANTHROPIC_AUTH_TOKEN"] = openrouter_key
@@ -3585,6 +3584,39 @@ def _validate_runtime_root(workspace_dir: str) -> str:
     if not resolved.exists() or not resolved.is_dir():
         raise ValueError(f"Invalid workspace_dir: {workspace_dir}")
     return str(resolved)
+
+
+def _resolve_repo_workspace(workspace_dir: str, repo: Any) -> str:
+    """根据 repo 名自动查找 workspace_dir 下对应的仓库子目录。
+
+    如果 workspace_dir 本身就是 git 仓库，直接返回。
+    否则尝试按 repo name（如 owner/TradeMaster -> TradeMaster）查找子目录。
+    """
+    base = Path(workspace_dir).expanduser().resolve()
+    if not base.exists() or not base.is_dir():
+        raise ValueError(f"Invalid workspace_dir: {workspace_dir}")
+
+    # workspace_dir 本身是 git 仓库
+    if (base / ".git").exists():
+        return str(base)
+
+    # 从 repo (owner/name) 提取 name，在 workspace_dir 下查找
+    repo_str = str(repo or "").strip()
+    if "/" in repo_str:
+        repo_name = repo_str.split("/")[-1]
+        # 精确匹配
+        candidate = base / repo_name
+        if candidate.is_dir() and (candidate / ".git").exists():
+            return str(candidate)
+        # 大小写不敏感匹配
+        for child in base.iterdir():
+            if child.is_dir() and child.name.lower() == repo_name.lower():
+                if (child / ".git").exists():
+                    return str(child)
+
+    raise ValueError(
+        f"No git repository found for repo '{repo_str}' in {workspace_dir}"
+    )
 
 
 def _sanitize_log_text(text: str) -> str:

--- a/app/services/feature_flags.py
+++ b/app/services/feature_flags.py
@@ -348,6 +348,8 @@ def _normalize_runtime(value: str | None) -> str:
 
 def _normalize_provider(value: str | None) -> str:
     normalized = str(value or "").strip().lower()
+    if not normalized:
+        return ""
     if normalized == CLAUDE_AGENT_PROVIDER_ZHIPU:
         return CLAUDE_AGENT_PROVIDER_ZHIPU
     if normalized == CLAUDE_AGENT_PROVIDER_DEEPSEEK:


### PR DESCRIPTION
## Summary
- Allow issue_comment from bot actors (AI Review tools like OpenCode/GLM post via github-actions[bot])
- Fetch head_sha/branch via GitHub API for issue_comment events (payload doesn't include them)
- Add github_token config field for API calls
- Inherit full process environment for subprocess (proxy/auth support)
- Auto-resolve repo workspace from workspace_dir by repo name (multi-repo support)
- Allow empty provider to skip openrouter override (support oauth token auth)

## Test plan
- [x] TradeMaster PR#4 全流程跑通：Webhook → 事件入库 → Worker 修复 → Push