### PR TITLE
[codex] require merge verdict in opencode review

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -47,6 +47,13 @@ jobs:
             - Suggest improvements
 
             Please respond in Chinese. DO NOT modify any code, only provide review comments.
+
+            Please use the following output format:
+            1. 结论: 可合并 / 有条件可合并 / 不可合并
+            2. 原因: 用 1-3 句话说明为什么给出这个结论
+            3. 问题清单:
+               - 如果发现问题，请按严重程度列出，并尽量附上文件路径和原因
+               - 如果没有发现需要阻塞合并的问题，请明确写“未发现需要阻塞合并的问题”
           USE_GITHUB_TOKEN: "true"
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- require the OpenCode review prompt to output a fixed merge verdict field
- keep the workflow read-only behavior unchanged and only tighten the review response contract
- make the review include a verdict, a short rationale, and a structured findings section

## Root cause
The existing prompt asked for review comments and checks, but it never required the reviewer to say whether the PR is mergeable. That made the output less structured and forced maintainers to infer the overall recommendation from scattered comments.

Closes #182.

## Validation
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/workflows/opencode-review.yml"); prompt = data.dig("jobs", "review", "steps", 3, "env", "PROMPT"); raise "missing verdict format" unless prompt.include?("结论: 可合并 / 有条件可合并 / 不可合并"); puts "yaml-ok"'`
- `git diff --check`
- `pytest -q`
