### PR TITLE
refactor: route manual issue context via provider

### DIFF
--- a/app/providers/github.py
+++ b/app/providers/github.py
@@ -363,6 +363,70 @@ class GitHubTaskSourceProvider:
         except (TypeError, ValueError):
             return None
 
+    def resolve_manual_issue_context(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        issue_number: int | None,
+        source_kind: str,
+        source_ref: str,
+        source_fragment: str,
+        description_present: bool,
+    ) -> Mapping[str, Any] | None:
+        fragment = source_fragment.strip().lower()
+
+        try:
+            if source_kind == "issue":
+                comment_id = _parse_fragment_numeric_id(fragment, ("issuecomment-",))
+                if comment_id is not None:
+                    return self._fetch_issue_comment_context(
+                        repo=repo,
+                        comment_id=comment_id,
+                        source_ref=source_ref,
+                    )
+                if not fragment:
+                    return self._fetch_issue_body_context(
+                        repo=repo,
+                        issue_number=issue_number or pr_number,
+                        source_ref=source_ref,
+                    )
+                return None
+
+            issue_comment_id = _parse_fragment_numeric_id(fragment, ("issuecomment-",))
+            if issue_comment_id is not None:
+                return self._fetch_issue_comment_context(
+                    repo=repo,
+                    comment_id=issue_comment_id,
+                    source_ref=source_ref,
+                )
+
+            review_comment_id = _parse_fragment_numeric_id(
+                fragment,
+                ("discussion_r", "r"),
+            )
+            if review_comment_id is not None:
+                return self._fetch_review_comment_context(
+                    repo=repo,
+                    comment_id=review_comment_id,
+                    source_ref=source_ref,
+                )
+
+            review_id = _parse_fragment_numeric_id(fragment, ("pullrequestreview-",))
+            if review_id is not None:
+                return self._fetch_review_context(
+                    repo=repo,
+                    pr_number=pr_number,
+                    review_id=review_id,
+                    source_ref=source_ref,
+                )
+        except ValueError:
+            if description_present:
+                return None
+            raise
+
+        return None
+
     def _parse_issue_url(self, url: str) -> Mapping[str, Any]:
         normalized_url = url.strip()
         parsed = urlparse(normalized_url)
@@ -422,6 +486,121 @@ class GitHubTaskSourceProvider:
             "source_kind": "issue",
             "task_title": None,
             "task_text": None,
+        }
+
+    def _fetch_issue_body_context(
+        self,
+        *,
+        repo: str,
+        issue_number: int,
+        source_ref: str,
+    ) -> Mapping[str, Any]:
+        payload = self._github_get_json(
+            f"{_GITHUB_API_BASE_URL}/repos/{repo}/issues/{issue_number}",
+            not_found_message="Issue not found or unavailable.",
+        )
+        title = _safe_text(payload.get("title")) or ""
+        body = _safe_text(payload.get("body")) or ""
+        if not title and not body:
+            raise ValueError(
+                "GitHub issue has no body text. Add a description to the manual issue."
+            )
+        context_body = body or title
+        return {
+            "text": _format_manual_issue_context(
+                label="GitHub issue context",
+                title=title,
+                body=context_body,
+            ),
+            "path": None,
+            "line": None,
+            "source_url": _safe_text(payload.get("html_url")) or source_ref,
+        }
+
+    def _fetch_issue_comment_context(
+        self,
+        *,
+        repo: str,
+        comment_id: int,
+        source_ref: str,
+    ) -> Mapping[str, Any]:
+        payload = self._github_get_json(
+            f"{_GITHUB_API_BASE_URL}/repos/{repo}/issues/comments/{comment_id}",
+            not_found_message="GitHub issue comment not found or unavailable.",
+        )
+        body = _safe_text(payload.get("body")) or ""
+        if not body:
+            raise ValueError(
+                "GitHub issue comment is empty. Add a description to the manual issue."
+            )
+        return {
+            "text": _format_manual_issue_context(
+                label="GitHub issue comment",
+                body=body,
+            ),
+            "path": None,
+            "line": None,
+            "source_url": _safe_text(payload.get("html_url")) or source_ref,
+        }
+
+    def _fetch_review_comment_context(
+        self,
+        *,
+        repo: str,
+        comment_id: int,
+        source_ref: str,
+    ) -> Mapping[str, Any]:
+        payload = self._github_get_json(
+            f"{_GITHUB_API_BASE_URL}/repos/{repo}/pulls/comments/{comment_id}",
+            not_found_message="GitHub review comment not found or unavailable.",
+        )
+        body = _safe_text(payload.get("body")) or ""
+        if not body:
+            raise ValueError(
+                "GitHub review comment is empty. Add a description to the manual issue."
+            )
+        path = _safe_text(payload.get("path"))
+        line = _coerce_positive_int(payload.get("line")) or _coerce_positive_int(
+            payload.get("original_line")
+        )
+        return {
+            "text": _format_manual_issue_context(
+                label="GitHub review comment",
+                body=body,
+                path=path,
+                line=line,
+            ),
+            "path": path,
+            "line": line,
+            "source_url": _safe_text(payload.get("html_url")) or source_ref,
+        }
+
+    def _fetch_review_context(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        review_id: int,
+        source_ref: str,
+    ) -> Mapping[str, Any]:
+        payload = self._github_get_json(
+            f"{_GITHUB_API_BASE_URL}/repos/{repo}/pulls/{pr_number}/reviews/{review_id}",
+            not_found_message="GitHub pull request review not found or unavailable.",
+        )
+        body = _safe_text(payload.get("body")) or ""
+        if not body:
+            raise ValueError(
+                "GitHub pull request review is empty. Add a description to the manual issue."
+            )
+        state = _safe_text(payload.get("state"))
+        label = "GitHub pull request review"
+        if state:
+            label = f"{label} ({state.lower()})"
+        return {
+            "text": _format_manual_issue_context(label=label, body=body),
+            "path": None,
+            "line": None,
+            "source_url": _safe_text(payload.get("html_url")) or source_ref,
         }
 
     def _github_headers(self) -> dict[str, str]:
@@ -575,6 +754,49 @@ def _parse_positive_int_from_text(raw_value: str, *, error_message: str) -> int:
     if parsed <= 0:
         raise ValueError(error_message)
     return parsed
+
+
+def _parse_fragment_numeric_id(fragment: str, prefixes: tuple[str, ...]) -> int | None:
+    normalized = fragment.strip().lower()
+    for prefix in prefixes:
+        if normalized.startswith(prefix):
+            suffix = normalized[len(prefix) :]
+            try:
+                parsed_id = int(suffix)
+            except ValueError:
+                return None
+            return parsed_id if parsed_id > 0 else None
+    return None
+
+
+def _format_manual_issue_context(
+    *,
+    label: str,
+    body: str,
+    title: str = "",
+    path: str | None = None,
+    line: int | None = None,
+) -> str:
+    parts = [label]
+    if title:
+        parts.append(f"Title: {title}")
+    if path:
+        location = f"File: {path}"
+        if line is not None:
+            location += f":{line}"
+        parts.append(location)
+    parts.append(body)
+    return "\n".join(part for part in parts if part)
+
+
+def _coerce_positive_int(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
 
 
 def _safe_text(value: Any) -> str | None:

--- a/app/providers/types.py
+++ b/app/providers/types.py
@@ -90,6 +90,18 @@ class TaskSourceProvider(Protocol):
         issue_number: int,
     ) -> int | None: ...
 
+    def resolve_manual_issue_context(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        issue_number: int | None,
+        source_kind: str,
+        source_ref: str,
+        source_fragment: str,
+        description_present: bool,
+    ) -> Mapping[str, Any] | None: ...
+
 
 @runtime_checkable
 class WebhookProvider(Protocol):

--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -1,14 +1,11 @@
 import csv
 import io
 import json
-import os
 import sqlite3
 from dataclasses import dataclass
-from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, Mapping
 
-import httpx
 from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
@@ -431,218 +428,10 @@ def _parse_task_submission(payload: IssueSubmissionRequest) -> ParsedTaskTarget:
     )
 
 
-def _github_token() -> str:
-    for key in (
-        "GITHUB_TOKEN",
-        "GH_TOKEN",
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "GITHUB_RELEASE_TOKEN",
-    ):
-        value = os.environ.get(key, "").strip()
-        if value:
-            return value
-    return ""
-
-
-def _github_headers() -> dict[str, str]:
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "User-Agent": "software-factory",
-    }
-    token = _github_token()
-    if token:
-        headers["Authorization"] = f"token {token}"
-    return headers
-
-
-def _github_get_json(url: str, *, not_found_message: str) -> dict[str, Any]:
-    try:
-        response = httpx.get(url, headers=_github_headers(), timeout=10.0)
-    except httpx.RequestError as exc:
-        raise ValueError(f"Failed to query GitHub details: {exc}") from exc
-
-    if response.status_code == 404:
-        raise ValueError(not_found_message)
-    if response.status_code == 403:
-        raise ValueError(
-            "GitHub API access denied while resolving manual issue details."
-        )
-    if response.status_code == 401:
-        raise ValueError("Unauthorized when querying GitHub manual issue details.")
-    if response.status_code >= 400:
-        raise ValueError(
-            f"GitHub API returned unexpected status: {response.status_code}."
-        )
-
-    try:
-        payload = response.json()
-    except JSONDecodeError as exc:
-        raise ValueError("GitHub API returned invalid JSON.") from exc
-    if not isinstance(payload, dict):
-        raise ValueError("Unexpected response from GitHub API.")
-    return payload
-
-
-def _github_get_list(url: str, *, not_found_message: str) -> list[dict[str, Any]]:
-    try:
-        response = httpx.get(url, headers=_github_headers(), timeout=10.0)
-    except httpx.RequestError as exc:
-        raise ValueError(f"Failed to query GitHub details: {exc}") from exc
-
-    if response.status_code == 404:
-        raise ValueError(not_found_message)
-    if response.status_code == 403:
-        raise ValueError(
-            "GitHub API access denied while resolving manual issue details."
-        )
-    if response.status_code == 401:
-        raise ValueError("Unauthorized when querying GitHub manual issue details.")
-    if response.status_code >= 400:
-        raise ValueError(
-            f"GitHub API returned unexpected status: {response.status_code}."
-        )
-
-    try:
-        payload = response.json()
-    except JSONDecodeError as exc:
-        raise ValueError("GitHub API returned invalid JSON.") from exc
-    if not isinstance(payload, list):
-        raise ValueError("Unexpected response from GitHub API.")
-    return [item for item in payload if isinstance(item, dict)]
-
-
-def _parse_fragment_numeric_id(fragment: str, prefixes: tuple[str, ...]) -> int | None:
-    normalized = fragment.strip().lower()
-    for prefix in prefixes:
-        if normalized.startswith(prefix):
-            suffix = normalized[len(prefix) :]
-            try:
-                parsed_id = int(suffix)
-            except ValueError:
-                return None
-            return parsed_id if parsed_id > 0 else None
-    return None
-
-
 def _string_or_empty(value: Any) -> str:
     if value is None:
         return ""
     return str(value).strip()
-
-
-def _format_manual_issue_context(
-    *,
-    label: str,
-    body: str,
-    title: str = "",
-    path: str | None = None,
-    line: int | None = None,
-) -> str:
-    parts = [label]
-    if title:
-        parts.append(f"Title: {title}")
-    if path:
-        location = f"File: {path}"
-        if line is not None:
-            location += f":{line}"
-        parts.append(location)
-    parts.append(body)
-    return "\n".join(part for part in parts if part)
-
-
-def _fetch_issue_body_context(target: ParsedTaskTarget) -> ManualIssueContext:
-    issue_number = target.issue_number or target.pr_number
-    payload = _github_get_json(
-        f"https://api.github.com/repos/{target.repo}/issues/{issue_number}",
-        not_found_message="Issue not found or unavailable.",
-    )
-    title = _string_or_empty(payload.get("title"))
-    body = _string_or_empty(payload.get("body"))
-    if not title and not body:
-        raise ValueError(
-            "GitHub issue has no body text. Add a description to the manual issue."
-        )
-    context_body = body or title
-    return ManualIssueContext(
-        text=_format_manual_issue_context(
-            label="GitHub issue context",
-            title=title,
-            body=context_body,
-        ),
-        source_url=_string_or_empty(payload.get("html_url")) or target.source_ref,
-    )
-
-
-def _fetch_issue_comment_context(
-    target: ParsedTaskTarget, comment_id: int
-) -> ManualIssueContext:
-    payload = _github_get_json(
-        f"https://api.github.com/repos/{target.repo}/issues/comments/{comment_id}",
-        not_found_message="GitHub issue comment not found or unavailable.",
-    )
-    body = _string_or_empty(payload.get("body"))
-    if not body:
-        raise ValueError(
-            "GitHub issue comment is empty. Add a description to the manual issue."
-        )
-    return ManualIssueContext(
-        text=_format_manual_issue_context(
-            label="GitHub issue comment",
-            body=body,
-        ),
-        source_url=_string_or_empty(payload.get("html_url")) or target.source_ref,
-    )
-
-
-def _fetch_review_comment_context(
-    target: ParsedTaskTarget, comment_id: int
-) -> ManualIssueContext:
-    payload = _github_get_json(
-        f"https://api.github.com/repos/{target.repo}/pulls/comments/{comment_id}",
-        not_found_message="GitHub review comment not found or unavailable.",
-    )
-    body = _string_or_empty(payload.get("body"))
-    if not body:
-        raise ValueError(
-            "GitHub review comment is empty. Add a description to the manual issue."
-        )
-    path = _string_or_empty(payload.get("path")) or None
-    line = coerce_positive_int(payload.get("line")) or coerce_positive_int(
-        payload.get("original_line")
-    )
-    return ManualIssueContext(
-        text=_format_manual_issue_context(
-            label="GitHub review comment",
-            body=body,
-            path=path,
-            line=line,
-        ),
-        path=path,
-        line=line,
-        source_url=_string_or_empty(payload.get("html_url")) or target.source_ref,
-    )
-
-
-def _fetch_review_context(
-    target: ParsedTaskTarget, review_id: int
-) -> ManualIssueContext:
-    payload = _github_get_json(
-        f"https://api.github.com/repos/{target.repo}/pulls/{target.pr_number}/reviews/{review_id}",
-        not_found_message="GitHub pull request review not found or unavailable.",
-    )
-    body = _string_or_empty(payload.get("body"))
-    if not body:
-        raise ValueError(
-            "GitHub pull request review is empty. Add a description to the manual issue."
-        )
-    state = _string_or_empty(payload.get("state"))
-    label = "GitHub pull request review"
-    if state:
-        label = f"{label} ({state.lower()})"
-    return ManualIssueContext(
-        text=_format_manual_issue_context(label=label, body=body),
-        source_url=_string_or_empty(payload.get("html_url")) or target.source_ref,
-    )
 
 
 def _resolve_manual_issue_context(
@@ -650,37 +439,33 @@ def _resolve_manual_issue_context(
     *,
     description_present: bool,
 ) -> ManualIssueContext | None:
-    fragment = target.source_fragment.strip().lower()
+    provider = get_task_source_provider()
+    raw_context = provider.resolve_manual_issue_context(
+        repo=target.repo,
+        pr_number=target.pr_number,
+        issue_number=target.issue_number,
+        source_kind=target.source_kind,
+        source_ref=target.source_ref,
+        source_fragment=target.source_fragment,
+        description_present=description_present,
+    )
+    if raw_context is None:
+        return None
+    if not isinstance(raw_context, Mapping):
+        raise ValueError("Unexpected response from task-source provider.")
 
-    try:
-        if target.source_kind == "issue":
-            comment_id = _parse_fragment_numeric_id(fragment, ("issuecomment-",))
-            if comment_id is not None:
-                return _fetch_issue_comment_context(target, comment_id)
-            if not fragment:
-                return _fetch_issue_body_context(target)
-            return None
-
-        issue_comment_id = _parse_fragment_numeric_id(fragment, ("issuecomment-",))
-        if issue_comment_id is not None:
-            return _fetch_issue_comment_context(target, issue_comment_id)
-
-        review_comment_id = _parse_fragment_numeric_id(
-            fragment,
-            ("discussion_r", "r"),
-        )
-        if review_comment_id is not None:
-            return _fetch_review_comment_context(target, review_comment_id)
-
-        review_id = _parse_fragment_numeric_id(fragment, ("pullrequestreview-",))
-        if review_id is not None:
-            return _fetch_review_context(target, review_id)
-    except ValueError:
+    context_text = _string_or_empty(raw_context.get("text"))
+    if not context_text:
         if description_present:
             return None
-        raise
+        raise ValueError("Manual issue context is empty.")
 
-    return None
+    return ManualIssueContext(
+        text=context_text,
+        path=_string_or_empty(raw_context.get("path")) or None,
+        line=coerce_positive_int(raw_context.get("line")),
+        source_url=_string_or_empty(raw_context.get("source_url")) or target.source_ref,
+    )
 
 
 def _fetch_pull_request_feedback_review(

--- a/tests/test_issue_submission.py
+++ b/tests/test_issue_submission.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from json import JSONDecodeError
 import os
 import sqlite3
 
@@ -464,13 +463,17 @@ def test_submit_issue_api_rejects_pull_request_url_without_actionable_feedback(
 
 
 def test_resolve_pr_number_from_issue_rejects_invalid_json(monkeypatch) -> None:
-    class _Response:
-        status_code = 200
+    class _FakeTaskSourceProvider:
+        def resolve_pull_request_number_from_issue(
+            self, *, repo: str, issue_number: int
+        ) -> int | None:
+            raise ValueError("GitHub API returned invalid JSON.")
 
-        def json(self):
-            raise JSONDecodeError("bad json", "", 0)
-
-    monkeypatch.setattr(web.httpx, "get", lambda *args, **kwargs: _Response())
+    monkeypatch.setattr(
+        web,
+        "get_task_source_provider",
+        lambda: _FakeTaskSourceProvider(),
+    )
 
     with pytest.raises(ValueError, match="invalid JSON"):
         web._resolve_pr_number_from_issue(
@@ -483,17 +486,17 @@ def test_resolve_pr_number_from_issue_rejects_invalid_json(monkeypatch) -> None:
 def test_resolve_pr_number_from_issue_returns_none_for_invalid_pull_request_url(
     monkeypatch,
 ) -> None:
-    class _Response:
-        status_code = 200
+    class _FakeTaskSourceProvider:
+        def resolve_pull_request_number_from_issue(
+            self, *, repo: str, issue_number: int
+        ) -> int | None:
+            return None
 
-        def json(self):
-            return {
-                "pull_request": {
-                    "url": "https://api.github.com/repos/acme/widgets/pulls/not-a-number"
-                }
-            }
-
-    monkeypatch.setattr(web.httpx, "get", lambda *args, **kwargs: _Response())
+    monkeypatch.setattr(
+        web,
+        "get_task_source_provider",
+        lambda: _FakeTaskSourceProvider(),
+    )
 
     assert (
         web._resolve_pr_number_from_issue(

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -109,6 +109,24 @@ class _CustomTaskSourceProvider:
     ) -> int | None:
         return issue_number
 
+    def resolve_manual_issue_context(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        issue_number: int | None,
+        source_kind: str,
+        source_ref: str,
+        source_fragment: str,
+        description_present: bool,
+    ) -> Mapping[str, Any] | None:
+        return {
+            "text": "context",
+            "path": None,
+            "line": None,
+            "source_url": source_ref,
+        }
+
 
 class _CustomWebhookProvider:
     name = "custom"


### PR DESCRIPTION
## Summary
- add `resolve_manual_issue_context` to the task-source provider contract and implement the GitHub provider path for issue/review context extraction
- move manual issue context lookup logic out of `app/routes/web.py` and route it through `get_task_source_provider()`
- remove duplicate GitHub API helper logic from web routes and update tests for protocol and delegation behavior

## Verification
- `python -m pytest -q tests/test_provider_registry.py tests/test_issue_submission.py tests/test_github_provider.py tests/test_web_runs.py tests/test_github_webhook_route.py`
- `python -m pytest -q`

## Linked issues
- Closes #193