### PR TITLE
feat: add Gitee provider

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -26,7 +26,7 @@ jobs:
         uses: Svtter/opencode-actions/review@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          model: opencode-go/glm-5.1
+          model: opencode-go/glm-5
           
           # only one is enough.
           opencode-go-api-key: ${{ secrets.OPENCODE_GO_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ Base settings:
 - `PORT` (`8000`): listen port
 - `DB_PATH` (`./data/software_factory.db`): SQLite file path
 - `GITHUB_WEBHOOK_SECRET` (empty): can be left empty for local debugging; production should enable signature verification
+- `GITEE_WEBHOOK_SECRET` (empty): used when `WEBHOOK_PROVIDER=gitee`
+- `GITHUB_TOKEN` (empty): GitHub API token for PR metadata, comments, and webhook enrichment
+- `GITEE_TOKEN` (empty): Gitee API token for PR metadata, comments, and webhook enrichment
+- `FORGE_PROVIDER` (`github`): forge provider, set to `gitee` to create/comment/query PRs on Gitee
+- `TASK_SOURCE_PROVIDER` (`github`): task-source provider, set to `gitee` to resolve Gitee task URLs
+- `WEBHOOK_PROVIDER` (`github`): webhook provider, set to `gitee` for Gitee webhook headers/signatures
+- `GIT_REMOTE_PROVIDER` (`github`): remote URL provider, set to `gitee` for clone and PR links
 
 Webhook settings:
 
@@ -312,6 +319,17 @@ curl -i -X POST http://127.0.0.1:8001/github/webhook \
 ```
 
 Note: `/github/webhook` already validates signatures. In production, `GITHUB_WEBHOOK_SECRET` should always be configured.
+
+Gitee provider example:
+
+```bash
+export FORGE_PROVIDER=gitee
+export TASK_SOURCE_PROVIDER=gitee
+export WEBHOOK_PROVIDER=gitee
+export GIT_REMOTE_PROVIDER=gitee
+export GITEE_WEBHOOK_SECRET="your-gitee-webhook-secret"
+export GITEE_TOKEN="your-gitee-token"
+```
 
 Syntax / bytecode compilation check:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -208,6 +208,13 @@ cp example.env .env
 - `PORT`（`8000`）：服务监听端口
 - `DB_PATH`（`./data/software_factory.db`）：SQLite 文件路径
 - `GITHUB_WEBHOOK_SECRET`（空字符串）：本地联调可留空；生产环境建议启用签名校验
+- `GITEE_WEBHOOK_SECRET`（空字符串）：当 `WEBHOOK_PROVIDER=gitee` 时使用
+- `GITHUB_TOKEN`（空字符串）：GitHub PR 元数据、评论和 webhook 补全所需 token
+- `GITEE_TOKEN`（空字符串）：Gitee PR 元数据、评论和 webhook 补全所需 token
+- `FORGE_PROVIDER`（`github`）：Forge provider，设为 `gitee` 可切换到 Gitee PR 能力
+- `TASK_SOURCE_PROVIDER`（`github`）：任务来源 provider，设为 `gitee` 可解析 Gitee 链接
+- `WEBHOOK_PROVIDER`（`github`）：Webhook provider，设为 `gitee` 可使用 Gitee 头和签名校验
+- `GIT_REMOTE_PROVIDER`（`github`）：远端地址 provider，设为 `gitee` 可生成 Gitee clone / PR 链接
 
 Webhook 配置：
 
@@ -306,6 +313,17 @@ curl -i -X POST http://127.0.0.1:8001/github/webhook \
 ```
 
 说明：`/github/webhook` 已实现签名校验；生产环境请务必配置 `GITHUB_WEBHOOK_SECRET`。
+
+Gitee provider 示例：
+
+```bash
+export FORGE_PROVIDER=gitee
+export TASK_SOURCE_PROVIDER=gitee
+export WEBHOOK_PROVIDER=gitee
+export GIT_REMOTE_PROVIDER=gitee
+export GITEE_WEBHOOK_SECRET="your-gitee-webhook-secret"
+export GITEE_TOKEN="your-gitee-token"
+```
 
 语法 / 字节码编译检查：
 

--- a/app/config.py
+++ b/app/config.py
@@ -28,6 +28,8 @@ class Settings(BaseSettings):
     db_path: str = "./data/software_factory.db"
     github_webhook_secret: str = ""
     github_token: str = ""
+    gitee_webhook_secret: str = ""
+    gitee_token: str = ""
     forge_provider: str = "github"
     task_source_provider: str = "github"
     webhook_provider: str = "github"

--- a/app/providers/__init__.py
+++ b/app/providers/__init__.py
@@ -1,5 +1,7 @@
 """Provider interfaces and registry utilities."""
 
+from app.providers import gitee, github
+
 from app.providers.registry import (
     FORGE_PROVIDER_CATEGORY,
     GIT_REMOTE_PROVIDER_CATEGORY,
@@ -62,4 +64,6 @@ __all__ = [
     "list_registered_provider_names",
     "snapshot_registry",
     "reset_provider_registry",
+    "github",
+    "gitee",
 ]

--- a/app/providers/gitee.py
+++ b/app/providers/gitee.py
@@ -1,0 +1,840 @@
+from __future__ import annotations
+
+import base64
+import dataclasses
+import hashlib
+import hmac
+import json
+import logging
+import os
+from json import JSONDecodeError
+from typing import Any, Mapping
+from urllib.parse import quote_plus, unquote_plus, urlparse
+
+import httpx
+
+from app.providers.github import (
+    _coerce_positive_int,
+    _format_manual_issue_context,
+    _parse_fragment_numeric_id,
+    _parse_positive_int_from_text,
+    _parse_repo,
+    _safe_text,
+)
+from app.services.agent_prompt import CHANGED_FILE_PATHS_LIMIT
+from app.services.github_events import extract_review_event
+from app.services.github_signature import (
+    SignatureFailureReason,
+    SignatureStatus,
+    SignatureVerificationResult,
+)
+from app.services.git_ops import _resolve_default_base_branch
+from app.services.normalizer import normalize_review_events
+from app.services.task_source import TEXT_SOURCE_KIND, build_manual_text_task_number
+
+
+logger = logging.getLogger(__name__)
+webhook_logger = logging.getLogger("webhook_debug")
+_GITEE_WEB_BASE_URL = "https://gitee.com"
+_GITEE_API_BASE_URL = "https://gitee.com/api/v5"
+_GITEE_SIGNATURE_HEADER = "X-Gitee-Token"
+_GITEE_EVENT_HEADER = "X-Gitee-Event"
+_GITEE_TIMESTAMP_HEADER = "X-Gitee-Timestamp"
+
+
+class GiteeForgeProvider:
+    name = "gitee"
+
+    def ensure_pull_request(
+        self,
+        *,
+        repo_dir: str,
+        repo: str,
+        head_branch: str,
+        base_branch: str | None = None,
+        title: str,
+        body: str,
+    ) -> Mapping[str, Any]:
+        token = _gitee_token()
+        if not token:
+            return {
+                "success": False,
+                "pr_number": None,
+                "pr_url": None,
+                "error": "GITEE_TOKEN is required to create pull requests.",
+                "existing": False,
+            }
+
+        resolved_base = base_branch
+        if resolved_base is None:
+            resolved_base, _ = _resolve_default_base_branch(repo_dir)
+        if not resolved_base:
+            return {
+                "success": False,
+                "pr_number": None,
+                "pr_url": None,
+                "error": "Could not resolve base branch.",
+                "existing": False,
+            }
+
+        existing = self._find_existing_pull_request(repo=repo, head_branch=head_branch)
+        if existing is not None:
+            return existing
+
+        try:
+            response = httpx.post(
+                f"{_GITEE_API_BASE_URL}/repos/{repo}/pulls",
+                headers=_gitee_headers(token),
+                timeout=10.0,
+                json={
+                    "head": head_branch,
+                    "base": resolved_base,
+                    "title": title,
+                    "body": body,
+                    "access_token": token,
+                },
+            )
+        except httpx.RequestError as exc:
+            return {
+                "success": False,
+                "pr_number": None,
+                "pr_url": None,
+                "error": str(exc),
+                "existing": False,
+            }
+
+        payload = _response_json_dict(response)
+        if response.status_code >= 400 or payload is None:
+            return {
+                "success": False,
+                "pr_number": None,
+                "pr_url": None,
+                "error": _response_error_message(response, payload),
+                "existing": False,
+            }
+
+        pr_number = _coerce_positive_int(payload.get("number"))
+        pr_url = _safe_text(payload.get("html_url"))
+        return {
+            "success": pr_number is not None,
+            "pr_number": pr_number,
+            "pr_url": pr_url,
+            "error": None if pr_number is not None else "missing_pull_request_number",
+            "existing": False,
+        }
+
+    def _find_existing_pull_request(
+        self, *, repo: str, head_branch: str
+    ) -> Mapping[str, Any] | None:
+        token = _gitee_token()
+        if not token:
+            return None
+        try:
+            response = httpx.get(
+                f"{_GITEE_API_BASE_URL}/repos/{repo}/pulls",
+                headers=_gitee_headers(token),
+                timeout=10.0,
+                params={"state": "open", "head": head_branch, "per_page": 100},
+            )
+        except httpx.RequestError:
+            return None
+
+        payload = _response_json_list(response)
+        if response.status_code >= 400 or payload is None:
+            return None
+        for item in payload:
+            head = item.get("head")
+            head_ref = (
+                _safe_text(head.get("ref")) if isinstance(head, Mapping) else None
+            )
+            if head_ref != head_branch:
+                continue
+            pr_number = _coerce_positive_int(item.get("number"))
+            pr_url = _safe_text(item.get("html_url"))
+            return {
+                "success": True,
+                "pr_number": pr_number,
+                "pr_url": pr_url,
+                "error": None,
+                "existing": True,
+            }
+        return None
+
+    def post_pull_request_comment(
+        self,
+        *,
+        repo_dir: str,
+        repo: str,
+        pr_number: int,
+        body: str,
+    ) -> tuple[bool, str]:
+        del repo_dir
+        token = _gitee_token()
+        if not token:
+            return False, "GITEE_TOKEN is required to post pull request comments."
+        try:
+            response = httpx.post(
+                f"{_GITEE_API_BASE_URL}/repos/{repo}/pulls/{pr_number}/comments",
+                headers=_gitee_headers(token),
+                timeout=10.0,
+                json={"body": body, "access_token": token},
+            )
+        except httpx.RequestError as exc:
+            return False, str(exc)
+        payload = _response_json_dict(response)
+        if response.status_code >= 400:
+            return False, _response_error_message(response, payload)
+        return True, _safe_text((payload or {}).get("html_url")) or "comment_posted"
+
+    def get_pull_request_metadata(
+        self,
+        *,
+        repo_dir: str,
+        repo: str,
+        pr_number: int,
+    ) -> Mapping[str, Any] | None:
+        del repo_dir
+        if pr_number <= 0:
+            return None
+        token = _gitee_token()
+        try:
+            response = httpx.get(
+                f"{_GITEE_API_BASE_URL}/repos/{repo}/pulls/{pr_number}",
+                headers=_gitee_headers(token),
+                timeout=10.0,
+            )
+        except httpx.RequestError:
+            return None
+        payload = _response_json_dict(response)
+        if response.status_code >= 400 or payload is None:
+            return None
+
+        base = payload.get("base")
+        head = payload.get("head")
+        return {
+            "title": _safe_text(payload.get("title")),
+            "body": _safe_text(payload.get("body")),
+            "base_ref": _safe_text(base.get("ref"))
+            if isinstance(base, Mapping)
+            else None,
+            "head_ref": _safe_text(head.get("ref"))
+            if isinstance(head, Mapping)
+            else None,
+            "head_sha": _safe_text(head.get("sha"))
+            if isinstance(head, Mapping)
+            else None,
+            "changed_files": payload.get("changed_files"),
+            "additions": payload.get("additions"),
+            "deletions": payload.get("deletions"),
+            "merge_state_status": _safe_text(payload.get("state")),
+            "can_be_rebased": None,
+            "mergeable": payload.get("mergeable"),
+            "is_merge_conflict": False,
+            "is_behind": False,
+            "is_blocked": False,
+            "changed_file_paths": self.collect_changed_file_paths(
+                repo_dir=repo_dir,
+                repo=repo,
+                pr_number=pr_number,
+            ),
+        }
+
+    def collect_changed_file_paths(
+        self,
+        *,
+        repo_dir: str,
+        repo: str,
+        pr_number: int,
+    ) -> list[str]:
+        del repo_dir
+        token = _gitee_token()
+        try:
+            response = httpx.get(
+                f"{_GITEE_API_BASE_URL}/repos/{repo}/pulls/{pr_number}/files",
+                headers=_gitee_headers(token),
+                timeout=10.0,
+            )
+        except httpx.RequestError:
+            return []
+        payload = _response_json_list(response)
+        if response.status_code >= 400 or payload is None:
+            return []
+        paths = [_safe_text(item.get("filename")) for item in payload]
+        return [path for path in paths if path][:CHANGED_FILE_PATHS_LIMIT]
+
+
+class GiteeTaskSourceProvider:
+    name = "gitee"
+
+    def parse_task_submission(
+        self, *, submission: Mapping[str, Any]
+    ) -> Mapping[str, Any]:
+        source_url = _safe_text(submission.get("url"))
+        if source_url:
+            return self._parse_issue_url(source_url)
+
+        normalized_repo, owner, repo_name = _parse_repo(
+            _safe_text(submission.get("repo")) or ""
+        )
+        task_text = _safe_text(submission.get("text"))
+        if not task_text:
+            raise ValueError("Task text is required for non-GitHub submissions.")
+        task_title = _safe_text(submission.get("title")) or None
+        return {
+            "repo": normalized_repo,
+            "owner": owner,
+            "repo_name": repo_name,
+            "pr_number": build_manual_text_task_number(
+                repo=normalized_repo,
+                text=task_text,
+                title=task_title,
+            ),
+            "resolved_pr_number": None,
+            "issue_number": None,
+            "source_ref": "",
+            "source_fragment": "",
+            "source_kind": TEXT_SOURCE_KIND,
+            "task_title": task_title,
+            "task_text": task_text,
+        }
+
+    def fetch_pull_request_feedback_review(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+    ) -> Mapping[str, Any]:
+        pr_comments = self._gitee_get_list(
+            f"{_GITEE_API_BASE_URL}/repos/{repo}/pulls/{pr_number}/comments?per_page=100",
+            not_found_message="Pull request comments not found or unavailable.",
+        )
+        issue_comments = self._gitee_get_list(
+            f"{_GITEE_API_BASE_URL}/repos/{repo}/issues/{pr_number}/comments?per_page=100",
+            not_found_message="Pull request issue comments not found or unavailable.",
+        )
+
+        source_ref = f"{_GITEE_WEB_BASE_URL}/{repo}/pulls/{pr_number}"
+        events: list[dict[str, Any]] = []
+        events.extend(
+            {
+                "event_type": "pull_request_review_comment",
+                "payload": {"comment": comment},
+            }
+            for comment in pr_comments
+        )
+        events.extend(
+            {
+                "event_type": "issue_comment",
+                "payload": {
+                    "issue": {"pull_request": {"url": source_ref}},
+                    "comment": comment,
+                },
+            }
+            for comment in issue_comments
+        )
+
+        normalized = normalize_review_events(
+            repo=repo,
+            pr_number=pr_number,
+            events=events,
+            head_sha=None,
+        )
+        normalized["project_type"] = "python"
+        normalized["source_kind"] = "pull"
+        normalized["resolved_pr_number"] = pr_number
+        normalized["manual_issue_source_url"] = source_ref
+        normalized["issue_number"] = None
+        return normalized
+
+    def resolve_pull_request_number_from_issue(
+        self,
+        *,
+        repo: str,
+        issue_number: int,
+    ) -> int | None:
+        payload = self._gitee_get_json(
+            f"{_GITEE_API_BASE_URL}/repos/{repo}/issues/{issue_number}",
+            not_found_message="Issue not found or unavailable.",
+        )
+        pull_request_info = payload.get("pull_request")
+        if not isinstance(pull_request_info, Mapping):
+            return None
+        pr_url = _safe_text(
+            pull_request_info.get("html_url") or pull_request_info.get("url")
+        )
+        if not pr_url:
+            return None
+        pull_url_parts = [part for part in pr_url.split("/") if part]
+        try:
+            return int(pull_url_parts[-1])
+        except (TypeError, ValueError):
+            return None
+
+    def resolve_manual_issue_context(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        issue_number: int | None,
+        source_kind: str,
+        source_ref: str,
+        source_fragment: str,
+        description_present: bool,
+    ) -> Mapping[str, Any] | None:
+        fragment = source_fragment.strip().lower()
+        try:
+            if source_kind == "issue":
+                note_id = _parse_fragment_numeric_id(fragment, ("note_",))
+                if note_id is not None:
+                    return self._fetch_issue_comment_context(
+                        repo=repo,
+                        comment_id=note_id,
+                        source_ref=source_ref,
+                    )
+                if not fragment:
+                    return self._fetch_issue_body_context(
+                        repo=repo,
+                        issue_number=issue_number or pr_number,
+                        source_ref=source_ref,
+                    )
+                return None
+
+            note_id = _parse_fragment_numeric_id(fragment, ("note_",))
+            if note_id is not None:
+                return self._fetch_review_comment_context(
+                    repo=repo,
+                    comment_id=note_id,
+                    source_ref=source_ref,
+                )
+        except ValueError:
+            if description_present:
+                return None
+            raise
+        return None
+
+    def _parse_issue_url(self, url: str) -> Mapping[str, Any]:
+        normalized_url = url.strip()
+        parsed = urlparse(normalized_url)
+        if parsed.scheme != "https" or (parsed.hostname or "").lower() != "gitee.com":
+            raise ValueError("Only https Gitee links on gitee.com are supported.")
+
+        path_parts = [part for part in parsed.path.split("/") if part]
+        if len(path_parts) < 4:
+            raise ValueError(
+                "Expected a Gitee URL in the form https://gitee.com/<owner>/<repo>/pulls/<number> "
+                "or https://gitee.com/<owner>/<repo>/issues/<number>."
+            )
+        owner, repo_name, section, number_part = path_parts[:4]
+        repo = f"{owner}/{repo_name}"
+        fragment = parsed.fragment.strip()
+
+        if section in {"pull", "pulls"}:
+            pr_number = _parse_positive_int_from_text(
+                number_part,
+                error_message="PR number in URL must be a positive integer.",
+            )
+            return {
+                "repo": repo,
+                "owner": owner,
+                "repo_name": repo_name,
+                "pr_number": pr_number,
+                "resolved_pr_number": pr_number,
+                "issue_number": None,
+                "source_ref": normalized_url,
+                "source_fragment": fragment,
+                "source_kind": "pull",
+                "task_title": None,
+                "task_text": None,
+            }
+
+        if section != "issues":
+            raise ValueError(
+                "Only pull request or issue links are supported. Example: "
+                "https://gitee.com/<owner>/<repo>/pulls/<number> or "
+                "https://gitee.com/<owner>/<repo>/issues/<number>."
+            )
+
+        issue_number = _parse_positive_int_from_text(
+            number_part,
+            error_message="Issue number in URL must be a positive integer.",
+        )
+        return {
+            "repo": repo,
+            "owner": owner,
+            "repo_name": repo_name,
+            "pr_number": issue_number,
+            "resolved_pr_number": None,
+            "issue_number": issue_number,
+            "source_ref": normalized_url,
+            "source_fragment": fragment,
+            "source_kind": "issue",
+            "task_title": None,
+            "task_text": None,
+        }
+
+    def _fetch_issue_body_context(
+        self,
+        *,
+        repo: str,
+        issue_number: int,
+        source_ref: str,
+    ) -> Mapping[str, Any]:
+        payload = self._gitee_get_json(
+            f"{_GITEE_API_BASE_URL}/repos/{repo}/issues/{issue_number}",
+            not_found_message="Issue not found or unavailable.",
+        )
+        title = _safe_text(payload.get("title")) or ""
+        body = _safe_text(payload.get("body")) or ""
+        if not title and not body:
+            raise ValueError(
+                "Gitee issue has no body text. Add a description to the manual issue."
+            )
+        context_body = body or title
+        return {
+            "text": _format_manual_issue_context(
+                label="Gitee issue context",
+                title=title,
+                body=context_body,
+            ),
+            "path": None,
+            "line": None,
+            "source_url": _safe_text(payload.get("html_url")) or source_ref,
+        }
+
+    def _fetch_issue_comment_context(
+        self,
+        *,
+        repo: str,
+        comment_id: int,
+        source_ref: str,
+    ) -> Mapping[str, Any]:
+        payload = self._gitee_get_json(
+            f"{_GITEE_API_BASE_URL}/repos/{repo}/issues/comments/{comment_id}",
+            not_found_message="Gitee issue comment not found or unavailable.",
+        )
+        body = _safe_text(payload.get("body")) or ""
+        if not body:
+            raise ValueError(
+                "Gitee issue comment is empty. Add a description to the manual issue."
+            )
+        return {
+            "text": _format_manual_issue_context(
+                label="Gitee issue comment", body=body
+            ),
+            "path": None,
+            "line": None,
+            "source_url": _safe_text(payload.get("html_url")) or source_ref,
+        }
+
+    def _fetch_review_comment_context(
+        self,
+        *,
+        repo: str,
+        comment_id: int,
+        source_ref: str,
+    ) -> Mapping[str, Any]:
+        payload = self._gitee_get_json(
+            f"{_GITEE_API_BASE_URL}/repos/{repo}/pulls/comments/{comment_id}",
+            not_found_message="Gitee pull request comment not found or unavailable.",
+        )
+        body = _safe_text(payload.get("body")) or ""
+        if not body:
+            raise ValueError(
+                "Gitee pull request comment is empty. Add a description to the manual issue."
+            )
+        path = _safe_text(payload.get("path"))
+        line = _coerce_positive_int(payload.get("line")) or _coerce_positive_int(
+            payload.get("original_line")
+        )
+        return {
+            "text": _format_manual_issue_context(
+                label="Gitee pull request comment",
+                body=body,
+                path=path,
+                line=line,
+            ),
+            "path": path,
+            "line": line,
+            "source_url": _safe_text(payload.get("html_url")) or source_ref,
+        }
+
+    def _gitee_get_json(self, url: str, *, not_found_message: str) -> dict[str, Any]:
+        try:
+            response = httpx.get(
+                url, headers=_gitee_headers(_gitee_token()), timeout=10.0
+            )
+        except httpx.RequestError as exc:
+            raise ValueError(f"Failed to query Gitee details: {exc}") from exc
+        if response.status_code == 404:
+            raise ValueError(not_found_message)
+        if response.status_code == 403:
+            raise ValueError(
+                "Gitee API access denied while resolving manual issue details."
+            )
+        if response.status_code == 401:
+            raise ValueError("Unauthorized when querying Gitee manual issue details.")
+        if response.status_code >= 400:
+            raise ValueError(
+                f"Gitee API returned unexpected status: {response.status_code}."
+            )
+        try:
+            payload = response.json()
+        except JSONDecodeError as exc:
+            raise ValueError("Gitee API returned invalid JSON.") from exc
+        if not isinstance(payload, dict):
+            raise ValueError("Unexpected response from Gitee API.")
+        return payload
+
+    def _gitee_get_list(
+        self, url: str, *, not_found_message: str
+    ) -> list[dict[str, Any]]:
+        try:
+            response = httpx.get(
+                url, headers=_gitee_headers(_gitee_token()), timeout=10.0
+            )
+        except httpx.RequestError as exc:
+            raise ValueError(f"Failed to query Gitee details: {exc}") from exc
+        if response.status_code == 404:
+            raise ValueError(not_found_message)
+        if response.status_code == 403:
+            raise ValueError(
+                "Gitee API access denied while resolving manual issue details."
+            )
+        if response.status_code == 401:
+            raise ValueError("Unauthorized when querying Gitee manual issue details.")
+        if response.status_code >= 400:
+            raise ValueError(
+                f"Gitee API returned unexpected status: {response.status_code}."
+            )
+        try:
+            payload = response.json()
+        except JSONDecodeError as exc:
+            raise ValueError("Gitee API returned invalid JSON.") from exc
+        if not isinstance(payload, list):
+            raise ValueError("Unexpected response from Gitee API.")
+        return [item for item in payload if isinstance(item, dict)]
+
+
+class GiteeWebhookProvider:
+    name = "gitee"
+
+    @property
+    def signature_header(self) -> str:
+        return _GITEE_SIGNATURE_HEADER
+
+    @property
+    def event_header(self) -> str:
+        return _GITEE_EVENT_HEADER
+
+    def verify_signature(
+        self,
+        *,
+        body: bytes,
+        secret: str,
+        signature_header: str | None,
+        request_headers: Mapping[str, Any] | None = None,
+    ) -> SignatureVerificationResult:
+        del body
+        if not secret.strip():
+            return SignatureVerificationResult(status=SignatureStatus.SKIPPED)
+        candidate = _safe_text(signature_header)
+        if not candidate:
+            return SignatureVerificationResult(
+                status=SignatureStatus.FAILED,
+                reason=SignatureFailureReason.MISSING_HEADER,
+            )
+        if hmac.compare_digest(candidate, secret.strip()):
+            return SignatureVerificationResult(status=SignatureStatus.VERIFIED)
+        timestamp = _safe_text((request_headers or {}).get(_GITEE_TIMESTAMP_HEADER))
+        if not timestamp and request_headers is not None:
+            timestamp = _safe_text(request_headers.get(_GITEE_TIMESTAMP_HEADER.lower()))
+        if not timestamp:
+            return SignatureVerificationResult(
+                status=SignatureStatus.FAILED,
+                reason=SignatureFailureReason.MISSING_HEADER,
+            )
+        expected = _build_gitee_signature(secret=secret.strip(), timestamp=timestamp)
+        normalized_candidate = unquote_plus(candidate)
+        if hmac.compare_digest(normalized_candidate, expected):
+            return SignatureVerificationResult(status=SignatureStatus.VERIFIED)
+        return SignatureVerificationResult(
+            status=SignatureStatus.FAILED,
+            reason=SignatureFailureReason.SIGNATURE_MISMATCH,
+        )
+
+    def extract_review_event(
+        self,
+        *,
+        event_type: str,
+        payload: Mapping[str, Any],
+    ) -> Any:
+        normalized_event = event_type.strip().lower()
+        if normalized_event != "note hook":
+            return None
+        noteable_type = _safe_text(payload.get("noteable_type")) or ""
+        if noteable_type.lower() not in {"pullrequest", "mergerequest"}:
+            return None
+        transformed_payload = _build_gitee_issue_comment_payload(payload)
+        if transformed_payload is None:
+            return None
+        event = extract_review_event("issue_comment", transformed_payload)
+        if event is None:
+            return None
+        return dataclasses.replace(
+            event,
+            event_key=event.event_key.replace("gh:", "gitee:", 1),
+        )
+
+    def extract_event_body(
+        self,
+        *,
+        event_type: str,
+        payload: Mapping[str, Any],
+    ) -> str | None:
+        if event_type.strip().lower() != "note hook":
+            return None
+        comment = payload.get("comment")
+        if not isinstance(comment, Mapping):
+            return None
+        return _safe_text(comment.get("body"))
+
+    def enrich_event_pull_request_info(
+        self,
+        *,
+        event: Any,
+        payload: Mapping[str, Any],
+        github_token: str,
+    ) -> tuple[Any, Mapping[str, Any]]:
+        repo = _safe_text(getattr(event, "repo", None))
+        pr_number = _coerce_positive_int(getattr(event, "pr_number", None))
+        if not repo or pr_number is None:
+            return event, payload
+        token = _safe_text(github_token)
+        if not token:
+            webhook_logger.warning(
+                "GITEE_TOKEN not set, cannot fetch PR info for %s#%s",
+                repo,
+                pr_number,
+            )
+            return event, payload
+        try:
+            response = httpx.get(
+                f"{_GITEE_API_BASE_URL}/repos/{repo}/pulls/{pr_number}",
+                headers=_gitee_headers(token),
+                timeout=10.0,
+            )
+            if response.status_code >= 400:
+                return event, payload
+            pr_data = response.json()
+            if not isinstance(pr_data, dict):
+                return event, payload
+            head = pr_data.get("head")
+            head_sha = (
+                _safe_text(head.get("sha")) if isinstance(head, Mapping) else None
+            )
+            if not head_sha:
+                return event, payload
+            event = dataclasses.replace(event, head_sha=head_sha)
+            enriched_payload = dict(payload)
+            enriched_payload["pull_request"] = pr_data
+            return event, enriched_payload
+        except Exception as exc:
+            webhook_logger.warning("Failed to fetch PR info from Gitee API: %s", exc)
+            return event, payload
+
+
+class GiteeGitRemoteProvider:
+    name = "gitee"
+
+    def build_clone_url(self, repo: str) -> str:
+        return f"{_GITEE_WEB_BASE_URL}/{repo}.git"
+
+    def build_pull_request_url(self, *, repo: str, pr_number: int) -> str:
+        return f"{_GITEE_WEB_BASE_URL}/{repo}/pulls/{pr_number}"
+
+    @property
+    def api_base_url(self) -> str:
+        return _GITEE_API_BASE_URL
+
+
+def _gitee_token() -> str:
+    for key in ("GITEE_TOKEN", "GITEE_ACCESS_TOKEN", "GITHUB_TOKEN"):
+        value = os.environ.get(key, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _gitee_headers(token: str) -> dict[str, str]:
+    headers = {"Accept": "application/json", "User-Agent": "software-factory"}
+    if token:
+        headers["Authorization"] = f"token {token}"
+    return headers
+
+
+def _response_json_dict(response: httpx.Response) -> dict[str, Any] | None:
+    try:
+        payload = response.json()
+    except JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _response_json_list(response: httpx.Response) -> list[dict[str, Any]] | None:
+    try:
+        payload = response.json()
+    except JSONDecodeError:
+        return None
+    if not isinstance(payload, list):
+        return None
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _response_error_message(
+    response: httpx.Response, payload: Mapping[str, Any] | None
+) -> str:
+    message = _safe_text((payload or {}).get("message"))
+    if message:
+        return message
+    return f"Gitee API returned status {response.status_code}."
+
+
+def _build_gitee_issue_comment_payload(
+    payload: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    repository = payload.get("repository")
+    comment = payload.get("comment")
+    pull_request = payload.get("pull_request")
+    if not isinstance(repository, Mapping):
+        return None
+    if not isinstance(comment, Mapping) or not isinstance(pull_request, Mapping):
+        return None
+    repo = _safe_text(
+        repository.get("path_with_namespace") or repository.get("full_name")
+    )
+    pr_number = _coerce_positive_int(pull_request.get("number"))
+    if not repo or pr_number is None:
+        return None
+    return {
+        "repository": {"full_name": repo},
+        "issue": {
+            "number": pr_number,
+            "pull_request": {
+                "url": _safe_text(pull_request.get("html_url"))
+                or f"{_GITEE_WEB_BASE_URL}/{repo}/pulls/{pr_number}"
+            },
+        },
+        "comment": comment,
+        "pull_request": pull_request,
+        "sender": payload.get("sender"),
+    }
+
+
+def _build_gitee_signature(*, secret: str, timestamp: str) -> str:
+    string_to_sign = f"{timestamp}\n{secret}".encode("utf-8")
+    digest = hmac.new(secret.encode("utf-8"), string_to_sign, hashlib.sha256).digest()
+    return base64.b64encode(digest).decode("utf-8")
+
+
+def build_signed_gitee_token(*, secret: str, timestamp: str) -> str:
+    return quote_plus(_build_gitee_signature(secret=secret, timestamp=timestamp))

--- a/app/providers/github.py
+++ b/app/providers/github.py
@@ -691,13 +691,19 @@ class GitHubWebhookProvider:
     def signature_header(self) -> str:
         return GITHUB_SIGNATURE_HEADER
 
+    @property
+    def event_header(self) -> str:
+        return "X-GitHub-Event"
+
     def verify_signature(
         self,
         *,
         body: bytes,
         secret: str,
         signature_header: str | None,
+        request_headers: Mapping[str, Any] | None = None,
     ) -> Any:
+        del request_headers
         return verify_github_signature(
             body=body,
             secret=secret,

--- a/app/providers/registry.py
+++ b/app/providers/registry.py
@@ -395,6 +395,12 @@ def _read_provider_setting(category: str) -> str | None:
 
 
 def _register_builtin_defaults_locked() -> None:
+    from app.providers.gitee import (
+        GiteeForgeProvider,
+        GiteeGitRemoteProvider,
+        GiteeTaskSourceProvider,
+        GiteeWebhookProvider,
+    )
     from app.providers.github import (
         GitHubForgeProvider,
         GitHubGitRemoteProvider,
@@ -405,8 +411,22 @@ def _register_builtin_defaults_locked() -> None:
     _register_provider_locked(
         store=_forge_providers,
         category=FORGE_PROVIDER_CATEGORY,
+        name="gitee",
+        provider=GiteeForgeProvider(),
+        replace=False,
+    )
+    _register_provider_locked(
+        store=_forge_providers,
+        category=FORGE_PROVIDER_CATEGORY,
         name=DEFAULT_PROVIDER_NAME,
         provider=GitHubForgeProvider(),
+        replace=False,
+    )
+    _register_provider_locked(
+        store=_task_source_providers,
+        category=TASK_SOURCE_PROVIDER_CATEGORY,
+        name="gitee",
+        provider=GiteeTaskSourceProvider(),
         replace=False,
     )
     _register_provider_locked(
@@ -419,8 +439,22 @@ def _register_builtin_defaults_locked() -> None:
     _register_provider_locked(
         store=_webhook_providers,
         category=WEBHOOK_PROVIDER_CATEGORY,
+        name="gitee",
+        provider=GiteeWebhookProvider(),
+        replace=False,
+    )
+    _register_provider_locked(
+        store=_webhook_providers,
+        category=WEBHOOK_PROVIDER_CATEGORY,
         name=DEFAULT_PROVIDER_NAME,
         provider=GitHubWebhookProvider(),
+        replace=False,
+    )
+    _register_provider_locked(
+        store=_git_remote_providers,
+        category=GIT_REMOTE_PROVIDER_CATEGORY,
+        name="gitee",
+        provider=GiteeGitRemoteProvider(),
         replace=False,
     )
     _register_provider_locked(

--- a/app/providers/types.py
+++ b/app/providers/types.py
@@ -110,12 +110,16 @@ class WebhookProvider(Protocol):
     @property
     def signature_header(self) -> str: ...
 
+    @property
+    def event_header(self) -> str: ...
+
     def verify_signature(
         self,
         *,
         body: bytes,
         secret: str,
         signature_header: str | None,
+        request_headers: Mapping[str, Any] | None = None,
     ) -> Any: ...
 
     def extract_review_event(

--- a/app/routes/github.py
+++ b/app/routes/github.py
@@ -81,39 +81,44 @@ def _get_filter_reason_for_event(
 async def github_webhook(request: Request) -> dict[str, Any]:
     raw_body = await request.body()
     provider = get_webhook_provider()
+    provider_name = _provider_display_name(provider)
+    provider_key = _provider_name(provider)
     signature_result = provider.verify_signature(
         body=raw_body,
-        secret=get_settings().github_webhook_secret,
+        secret=_webhook_secret_for_provider(provider_key),
         signature_header=request.headers.get(provider.signature_header),
+        request_headers=request.headers,
     )
     if signature_result.status == SignatureStatus.FAILED:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail={
                 "ok": False,
-                "message": "Invalid GitHub webhook signature",
+                "message": f"Invalid {provider_name} webhook signature",
                 "reason": signature_result.reason,
             },
         )
 
     payload = await _read_payload(request)
-    event_type = request.headers.get("x-github-event", "unknown").strip().lower()
+    event_type = request.headers.get(provider.event_header, "unknown").strip().lower()
     event = provider.extract_review_event(event_type=event_type, payload=payload)
     if event is None:
         return {
             "ok": True,
-            "message": "GitHub webhook received",
+            "message": f"{provider_name} webhook received",
             "event_type": event_type,
             "ignored": True,
             "reason": "unsupported_or_non_pr_event",
             "signature": signature_result.status,
         }
 
+    normalized_event_type = _provider_event_type(event, fallback=event_type)
+
     if not event.head_sha and event.repo and event.pr_number:
         event, payload = provider.enrich_event_pull_request_info(
             event=event,
             payload=payload,
-            github_token=get_settings().github_token,
+            github_token=_webhook_token_for_provider(provider_key),
         )
 
     run_id: int | None = None
@@ -121,16 +126,19 @@ async def github_webhook(request: Request) -> dict[str, Any]:
     queue_status = "not_queued"
     remaining_quota: int | None = None
     runtime_settings: RuntimeSettings | None = None
-    should_ignore_actor = event_type in _REVIEW_EVENTS_ALLOWING_BOT_ACTORS
+    should_ignore_actor = normalized_event_type in _REVIEW_EVENTS_ALLOWING_BOT_ACTORS
     event_body = provider.extract_event_body(event_type=event_type, payload=payload)
     try:
         with connect_db() as conn:
             runtime_settings = resolve_runtime_settings(conn)
-            if _is_autofix_summary_comment(event_type=event_type, body=event_body):
+            if _is_autofix_summary_comment(
+                event_type=normalized_event_type,
+                body=event_body,
+            ):
                 return {
                     "ok": True,
-                    "message": "GitHub webhook received",
-                    "event_type": event_type,
+                    "message": f"{provider_name} webhook received",
+                    "event_type": normalized_event_type,
                     "ignored": True,
                     "reason": "autofix_summary_comment",
                     "signature": signature_result.status,
@@ -138,7 +146,7 @@ async def github_webhook(request: Request) -> dict[str, Any]:
                     "pr_number": event.pr_number,
                 }
             filter_reason = _get_filter_reason_for_event(
-                event_type,
+                normalized_event_type,
                 repo=event.repo,
                 actor=None if should_ignore_actor else event.actor,
                 body=event_body,
@@ -147,8 +155,8 @@ async def github_webhook(request: Request) -> dict[str, Any]:
             if filter_reason is not None:
                 return {
                     "ok": True,
-                    "message": "GitHub webhook received",
-                    "event_type": event_type,
+                    "message": f"{provider_name} webhook received",
+                    "event_type": normalized_event_type,
                     "ignored": True,
                     "reason": filter_reason,
                     "signature": signature_result.status,
@@ -179,7 +187,7 @@ async def github_webhook(request: Request) -> dict[str, Any]:
                     pr_number=event.pr_number,
                     head_sha=event.head_sha,
                 )
-                if _should_enqueue_for_event(event_type):
+                if _should_enqueue_for_event(normalized_event_type):
                     review_batch_id = build_review_batch_id(normalized_review)
                     normalized_review["review_batch_id"] = review_batch_id
                     idempotency_key = build_task_idempotency_key(
@@ -232,8 +240,8 @@ async def github_webhook(request: Request) -> dict[str, Any]:
 
     return {
         "ok": True,
-        "message": "GitHub webhook received",
-        "event_type": event_type,
+        "message": f"{provider_name} webhook received",
+        "event_type": normalized_event_type,
         "signature": signature_result.status,
         "repo": event.repo,
         "pr_number": event.pr_number,
@@ -466,3 +474,35 @@ def _as_text(value: Any) -> str | None:
         if text:
             return text
     return None
+
+
+def _provider_display_name(provider: Any) -> str:
+    normalized_name = _provider_name(provider)
+    if normalized_name == "gitee":
+        return "Gitee"
+    return "GitHub"
+
+
+def _provider_name(provider: Any) -> str:
+    return str(getattr(provider, "name", "") or "github").strip().lower() or "github"
+
+
+def _webhook_secret_for_provider(provider_name: str) -> str:
+    settings = get_settings()
+    normalized_name = provider_name.strip().lower()
+    if normalized_name == "gitee":
+        return settings.gitee_webhook_secret
+    return settings.github_webhook_secret
+
+
+def _webhook_token_for_provider(provider_name: str) -> str:
+    settings = get_settings()
+    normalized_name = provider_name.strip().lower()
+    if normalized_name == "gitee":
+        return settings.gitee_token or settings.github_token
+    return settings.github_token
+
+
+def _provider_event_type(event: Any, *, fallback: str) -> str:
+    normalized = str(getattr(event, "event_type", "") or fallback).strip().lower()
+    return normalized or fallback.strip().lower()

--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -398,7 +398,7 @@ def _parse_task_submission(payload: IssueSubmissionRequest) -> ParsedTaskTarget:
         pr_number = resolved_pr_number or issue_number
     elif source_kind == TEXT_SOURCE_KIND:
         if not task_text:
-            raise ValueError("Task text is required for non-GitHub submissions.")
+            raise ValueError("Task text is required for direct text submissions.")
         if pr_number is None:
             pr_number = build_manual_text_task_number(
                 repo=repo,
@@ -432,6 +432,13 @@ def _string_or_empty(value: Any) -> str:
     if value is None:
         return ""
     return str(value).strip()
+
+
+def _task_source_context_label() -> str:
+    provider_name = str(get_task_source_provider().name or "github").strip().lower()
+    if provider_name == "gitee":
+        return "Gitee"
+    return "GitHub"
 
 
 def _resolve_manual_issue_context(
@@ -517,8 +524,9 @@ def _build_issue_normalized_review(
         issue_parts.append(f"Operator note:\n{description}")
     if resolved_context is not None:
         context_source = resolved_context.source_url or target.source_ref
-        issue_parts.append(f"GitHub context source: {context_source}")
-        issue_parts.append(f"GitHub context:\n{resolved_context.text}")
+        context_label = _task_source_context_label()
+        issue_parts.append(f"{context_label} context source: {context_source}")
+        issue_parts.append(f"{context_label} context:\n{resolved_context.text}")
 
     issue_text = "\n\n".join(part for part in issue_parts if part)
     context_resolved = bool(description or resolved_context is not None)

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -2,6 +2,19 @@
 
 See also: `docs/runtime-config.md` for the DB-vs-env ownership rules and the dev/prod rollout guidance for mutable runtime settings.
 
+## Provider selection
+
+The default provider remains GitHub. To run the same flow against Gitee, set:
+
+```bash
+export FORGE_PROVIDER=gitee
+export TASK_SOURCE_PROVIDER=gitee
+export WEBHOOK_PROVIDER=gitee
+export GIT_REMOTE_PROVIDER=gitee
+export GITEE_WEBHOOK_SECRET="your-gitee-webhook-secret"
+export GITEE_TOKEN="your-gitee-token"
+```
+
 ## Token safety: environment isolation
 
 **The `web` service must never receive AI tokens.** Only the `worker` needs them.

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -60,6 +60,11 @@ These settings must stay outside SQLite because they are bootstrap, deployment-s
 
 - `DB_PATH`
 - `GITHUB_WEBHOOK_SECRET`
+- `GITEE_WEBHOOK_SECRET`
+- `FORGE_PROVIDER`
+- `TASK_SOURCE_PROVIDER`
+- `WEBHOOK_PROVIDER`
+- `GIT_REMOTE_PROVIDER`
 - provider API keys and auth tokens
 - host / port
 - other deployment-only values that should not be changed from the product

--- a/tests/test_gitee_provider.py
+++ b/tests/test_gitee_provider.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+from urllib.parse import quote_plus
+
+import pytest
+
+from app.providers import gitee as gitee_provider
+from app.services.github_events import GitHubReviewEvent
+
+
+def _build_gitee_signature(*, secret: str, timestamp: str) -> str:
+    return quote_plus(
+        gitee_provider._build_gitee_signature(secret=secret, timestamp=timestamp)
+    )
+
+
+def test_gitee_git_remote_provider_builds_expected_urls() -> None:
+    provider = gitee_provider.GiteeGitRemoteProvider()
+
+    assert (
+        provider.build_clone_url("acme/widgets") == "https://gitee.com/acme/widgets.git"
+    )
+    assert (
+        provider.build_pull_request_url(repo="acme/widgets", pr_number=42)
+        == "https://gitee.com/acme/widgets/pulls/42"
+    )
+    assert provider.api_base_url == "https://gitee.com/api/v5"
+
+
+def test_gitee_task_source_provider_parses_pull_url() -> None:
+    provider = gitee_provider.GiteeTaskSourceProvider()
+
+    parsed = provider.parse_task_submission(
+        submission={"url": "https://gitee.com/acme/widgets/pulls/42"}
+    )
+
+    assert parsed == {
+        "repo": "acme/widgets",
+        "owner": "acme",
+        "repo_name": "widgets",
+        "pr_number": 42,
+        "resolved_pr_number": 42,
+        "issue_number": None,
+        "source_ref": "https://gitee.com/acme/widgets/pulls/42",
+        "source_fragment": "",
+        "source_kind": "pull",
+        "task_title": None,
+        "task_text": None,
+    }
+
+
+def test_gitee_webhook_provider_accepts_password_mode_signature() -> None:
+    provider = gitee_provider.GiteeWebhookProvider()
+
+    result = provider.verify_signature(
+        body=b"{}",
+        secret="top-secret",
+        signature_header="top-secret",
+        request_headers={"x-gitee-event": "Note Hook"},
+    )
+
+    assert result.ok is True
+
+
+def test_gitee_webhook_provider_accepts_signed_token_with_timestamp() -> None:
+    provider = gitee_provider.GiteeWebhookProvider()
+    timestamp = "1710000000000"
+
+    result = provider.verify_signature(
+        body=b"{}",
+        secret="SEC123",
+        signature_header=_build_gitee_signature(secret="SEC123", timestamp=timestamp),
+        request_headers={
+            "x-gitee-event": "Note Hook",
+            "x-gitee-timestamp": timestamp,
+        },
+    )
+
+    assert result.ok is True
+
+
+def test_gitee_webhook_provider_extracts_pull_request_comment_event() -> None:
+    provider = gitee_provider.GiteeWebhookProvider()
+
+    event = provider.extract_review_event(
+        event_type="Note Hook",
+        payload={
+            "repository": {"path_with_namespace": "acme/widgets"},
+            "noteable_type": "PullRequest",
+            "comment": {
+                "id": 3001,
+                "body": "Please fix",
+                "user": {"login": "reviewer"},
+            },
+            "pull_request": {
+                "number": 42,
+                "head": {"sha": "abc123"},
+            },
+            "sender": {"login": "reviewer"},
+        },
+    )
+
+    assert isinstance(event, GitHubReviewEvent)
+    assert event.repo == "acme/widgets"
+    assert event.pr_number == 42
+    assert event.event_type == "issue_comment"
+    assert event.actor == "reviewer"
+    assert event.head_sha == "abc123"
+
+
+def test_gitee_webhook_provider_enrich_event_fetches_pr_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _Response:
+        status_code = 200
+
+        def json(self):
+            return {
+                "head": {"sha": "abc123", "ref": "feature/test"},
+                "number": 42,
+            }
+
+    def fake_get(url: str, *, headers, timeout: float):
+        captured["url"] = url
+        captured["headers"] = dict(headers)
+        captured["timeout"] = timeout
+        return _Response()
+
+    monkeypatch.setattr(gitee_provider.httpx, "get", fake_get)
+
+    provider = gitee_provider.GiteeWebhookProvider()
+    event = GitHubReviewEvent(
+        repo="acme/widgets",
+        pr_number=42,
+        event_type="issue_comment",
+        event_id="3001",
+        event_key="gitee:issue_comment:acme/widgets:42:3001",
+        actor="reviewer",
+        head_sha=None,
+        raw_payload_json="{}",
+    )
+    payload = {
+        "repository": {"path_with_namespace": "acme/widgets"},
+        "comment": {"id": 3001, "body": "Please fix"},
+        "pull_request": {"number": 42},
+    }
+
+    enriched_event, enriched_payload = provider.enrich_event_pull_request_info(
+        event=event,
+        payload=payload,
+        github_token="gitee-token",
+    )
+
+    assert enriched_event.head_sha == "abc123"
+    assert enriched_payload["pull_request"]["head"]["sha"] == "abc123"
+    assert captured["url"] == "https://gitee.com/api/v5/repos/acme/widgets/pulls/42"
+    assert captured["headers"] == {
+        "Authorization": "token gitee-token",
+        "Accept": "application/json",
+        "User-Agent": "software-factory",
+    }
+
+
+def test_gitee_forge_provider_collect_changed_file_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _Response:
+        status_code = 200
+
+        def json(self):
+            return [
+                {"filename": "app/main.py"},
+                {"filename": "app/routes/web.py"},
+            ]
+
+    def fake_get(url: str, *, headers, timeout: float):
+        captured["url"] = url
+        captured["headers"] = dict(headers)
+        captured["timeout"] = timeout
+        return _Response()
+
+    monkeypatch.setattr(gitee_provider.httpx, "get", fake_get)
+    monkeypatch.setenv("GITEE_TOKEN", "gitee-token")
+
+    provider = gitee_provider.GiteeForgeProvider()
+    result = provider.collect_changed_file_paths(
+        repo_dir="/repo",
+        repo="acme/widgets",
+        pr_number=7,
+    )
+
+    assert result == ["app/main.py", "app/routes/web.py"]
+    assert (
+        captured["url"] == "https://gitee.com/api/v5/repos/acme/widgets/pulls/7/files"
+    )

--- a/tests/test_gitee_webhook_route.py
+++ b/tests/test_gitee_webhook_route.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import get_settings
+from app.main import app
+from app.routes.github import _get_debounce_backend
+
+
+def _set_env(tmp_path: Path, secret: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    get_settings.cache_clear()
+    _get_debounce_backend.cache_clear()
+    db_path = tmp_path / "software_factory.db"
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    monkeypatch.setenv("WEBHOOK_PROVIDER", "gitee")
+    monkeypatch.setenv("GITEE_WEBHOOK_SECRET", secret)
+    monkeypatch.setenv("GITEE_TOKEN", "gitee-token")
+    monkeypatch.setenv("GITHUB_WEBHOOK_DEBOUNCE_SECONDS", "60")
+    monkeypatch.setenv("MAX_AUTOFIX_PER_PR", "3")
+    monkeypatch.setenv("MAX_RETRY_ATTEMPTS", "3")
+    monkeypatch.setenv("MANAGED_REPO_PREFIXES", "acme/")
+
+
+def test_gitee_webhook_note_hook_queues_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_env(tmp_path, secret="top-secret", monkeypatch=monkeypatch)
+
+    payload = {
+        "repository": {"path_with_namespace": "acme/widgets"},
+        "noteable_type": "PullRequest",
+        "comment": {
+            "id": 3001,
+            "body": "Please fix",
+            "user": {"login": "reviewer"},
+        },
+        "pull_request": {
+            "number": 42,
+            "head": {"sha": "abc123", "ref": "feature/test"},
+        },
+        "sender": {"login": "reviewer"},
+    }
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/github/webhook",
+            json=payload,
+            headers={
+                "X-Gitee-Event": "Note Hook",
+                "X-Gitee-Token": "top-secret",
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["queue_status"] == "queued"
+    assert data["repo"] == "acme/widgets"
+    assert data["pr_number"] == 42
+    assert isinstance(data["queued_run_id"], int)

--- a/tests/test_github_webhook_route.py
+++ b/tests/test_github_webhook_route.py
@@ -62,9 +62,15 @@ def test_webhook_route_uses_webhook_provider(tmp_path: Path, monkeypatch) -> Non
     calls: dict[str, object] = {}
 
     class _FakeWebhookProvider:
+        name = "github"
+
         @property
         def signature_header(self) -> str:
             return "X-Custom-Signature"
+
+        @property
+        def event_header(self) -> str:
+            return "X-GitHub-Event"
 
         def verify_signature(
             self,
@@ -72,6 +78,7 @@ def test_webhook_route_uses_webhook_provider(tmp_path: Path, monkeypatch) -> Non
             body: bytes,
             secret: str,
             signature_header: str | None,
+            request_headers=None,
         ) -> SignatureVerificationResult:
             calls["verify"] = {
                 "body": body,
@@ -164,9 +171,15 @@ def test_webhook_route_uses_provider_for_issue_comment_pr_info_enrichment(
     calls: dict[str, object] = {}
 
     class _FakeWebhookProvider:
+        name = "github"
+
         @property
         def signature_header(self) -> str:
             return "X-Custom-Signature"
+
+        @property
+        def event_header(self) -> str:
+            return "X-GitHub-Event"
 
         def verify_signature(
             self,
@@ -174,6 +187,7 @@ def test_webhook_route_uses_provider_for_issue_comment_pr_info_enrichment(
             body: bytes,
             secret: str,
             signature_header: str | None,
+            request_headers=None,
         ) -> SignatureVerificationResult:
             return SignatureVerificationResult(status=SignatureStatus.VERIFIED)
 

--- a/tests/test_issue_submission.py
+++ b/tests/test_issue_submission.py
@@ -105,6 +105,21 @@ def test_parse_task_submission_uses_resolve_helper_for_issue(monkeypatch) -> Non
     assert target.source_kind == "issue"
 
 
+def test_parse_task_submission_supports_gitee_pull_urls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TASK_SOURCE_PROVIDER", "gitee")
+    get_settings.cache_clear()
+
+    payload = IssueSubmissionRequest(url="https://gitee.com/acme/widgets/pulls/42")
+    target = web._parse_task_submission(payload)
+
+    assert target.repo == "acme/widgets"
+    assert target.pr_number == 42
+    assert target.resolved_pr_number == 42
+    assert target.source_kind == "pull"
+
+
 def test_submit_issue_api_queues_autofix_run(tmp_path, monkeypatch) -> None:
     db_path = _setup_db(tmp_path)
 

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -138,18 +138,24 @@ class _CustomWebhookProvider:
     def signature_header(self) -> str:
         return "X-Custom-Signature"
 
+    @property
+    def event_header(self) -> str:
+        return "X-Custom-Event"
+
     def verify_signature(
         self,
         *,
         body: bytes,
         secret: str,
         signature_header: str | None,
+        request_headers: Mapping[str, Any] | None = None,
     ) -> Mapping[str, Any]:
         return {
             "ok": True,
             "body_length": len(body),
             "secret": secret,
             "signature": signature_header,
+            "request_headers": request_headers,
         }
 
     def extract_review_event(
@@ -198,10 +204,22 @@ def test_default_github_providers_are_registered() -> None:
     assert get_webhook_provider().name == "github"
     assert get_git_remote_provider().name == "github"
 
-    assert list_registered_provider_names(FORGE_PROVIDER_CATEGORY) == ("github",)
-    assert list_registered_provider_names(TASK_SOURCE_PROVIDER_CATEGORY) == ("github",)
-    assert list_registered_provider_names(WEBHOOK_PROVIDER_CATEGORY) == ("github",)
-    assert list_registered_provider_names(GIT_REMOTE_PROVIDER_CATEGORY) == ("github",)
+    assert list_registered_provider_names(FORGE_PROVIDER_CATEGORY) == (
+        "gitee",
+        "github",
+    )
+    assert list_registered_provider_names(TASK_SOURCE_PROVIDER_CATEGORY) == (
+        "gitee",
+        "github",
+    )
+    assert list_registered_provider_names(WEBHOOK_PROVIDER_CATEGORY) == (
+        "gitee",
+        "github",
+    )
+    assert list_registered_provider_names(GIT_REMOTE_PROVIDER_CATEGORY) == (
+        "gitee",
+        "github",
+    )
 
 
 def test_resolve_provider_name_uses_default_and_normalizes_case() -> None:
@@ -217,6 +235,7 @@ def test_register_forge_provider_supports_custom_lookup() -> None:
     assert get_forge_provider("custom") is custom
     assert list_registered_provider_names(FORGE_PROVIDER_CATEGORY) == (
         "custom",
+        "gitee",
         "github",
     )
 
@@ -228,6 +247,7 @@ def test_register_task_source_provider_supports_custom_lookup() -> None:
     assert get_task_source_provider("custom") is custom
     assert list_registered_provider_names(TASK_SOURCE_PROVIDER_CATEGORY) == (
         "custom",
+        "gitee",
         "github",
     )
 
@@ -239,6 +259,7 @@ def test_register_webhook_provider_supports_custom_lookup() -> None:
     assert get_webhook_provider("custom") is custom
     assert list_registered_provider_names(WEBHOOK_PROVIDER_CATEGORY) == (
         "custom",
+        "gitee",
         "github",
     )
 
@@ -250,6 +271,7 @@ def test_register_git_remote_provider_supports_custom_lookup() -> None:
     assert get_git_remote_provider("custom") is custom
     assert list_registered_provider_names(GIT_REMOTE_PROVIDER_CATEGORY) == (
         "custom",
+        "gitee",
         "github",
     )
 
@@ -277,7 +299,7 @@ def test_get_forge_provider_raises_for_unknown_provider_name() -> None:
     with pytest.raises(ProviderLookupError) as exc:
         get_forge_provider("missing")
 
-    assert "available: github" in str(exc.value)
+    assert "available: gitee, github" in str(exc.value)
 
 
 @pytest.mark.parametrize(
@@ -382,7 +404,7 @@ def test_get_provider_raises_for_unknown_configured_default_provider(
 
     message = str(exc.value)
     assert expected_fragment in message
-    assert "available: github" in message
+    assert "available: gitee, github" in message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #199

## Problem

The provider abstraction already existed, but runtime behavior was still effectively GitHub-only. Issue #199 requires a Gitee-backed path for forge actions, task parsing, webhook intake, and remote URL generation without changing the default GitHub behavior when no provider env vars are set.

## Approach

- Added a `gitee` provider implementation in `app/providers/gitee.py` for forge, task source, webhook, and git remote responsibilities.
- Registered `gitee` in the provider registry so `FORGE_PROVIDER`, `TASK_SOURCE_PROVIDER`, `WEBHOOK_PROVIDER`, and `GIT_REMOTE_PROVIDER` can switch behavior at runtime while blank or unset values still resolve to `github`.
- Wired webhook handling to accept Gitee headers and signature modes, enrich PR metadata through the Gitee API when needed, and keep the existing `/github/webhook` intake path working for the runner queue flow.
- Documented the required Gitee runtime settings and examples in `README.md`, `README.zh-CN.md`, and `docs/local-runtime.md`, including `GITEE_TOKEN` and `GITEE_WEBHOOK_SECRET`.

## Tests

- Added provider coverage for Gitee clone/PR URL generation, task URL parsing, webhook signature verification, webhook PR enrichment, and changed-file collection in `tests/test_gitee_provider.py`.
- Added webhook route coverage for `Note Hook` queueing in `tests/test_gitee_webhook_route.py`.
- Added registry assertions in `tests/test_provider_registry.py` to confirm `gitee` is registered and GitHub remains the default when provider env vars are blank or unset.
- Added task submission coverage for Gitee pull URLs in `tests/test_issue_submission.py`.