### PR TITLE
feature: 部署可使用的应用实例，允许用户BYOK

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -90,6 +90,7 @@ class Settings(BaseSettings):
     claude_agent_sdk_worktree_base_dir: str = ".software-factory-worktrees"
     repo_cache_base_dir: str = ".software-factory-repo-cache"
     run_workspace_base_dir: str = ".software-factory-run-workspaces"
+    byok_admin_token: str = ""
 
     @field_validator(
         "bot_logins",

--- a/app/config.py
+++ b/app/config.py
@@ -91,6 +91,7 @@ class Settings(BaseSettings):
     repo_cache_base_dir: str = ".software-factory-repo-cache"
     run_workspace_base_dir: str = ".software-factory-run-workspaces"
     byok_admin_token: str = ""
+    byok_encryption_key: str = ""
 
     @field_validator(
         "bot_logins",

--- a/app/db.py
+++ b/app/db.py
@@ -36,9 +36,10 @@ def init_db() -> None:
         _migrate_app_feature_flags(conn)
         _migrate_app_config_audit_log(conn)
         _migrate_run_result_pr_columns(conn)
+        _migrate_user_api_keys(conn)
 
 
-ALLOWED_TABLES = {"pull_requests", "autofix_runs"}
+ALLOWED_TABLES = {"pull_requests", "autofix_runs", "user_api_keys"}
 
 
 def _migrate_m6_columns(conn: sqlite3.Connection) -> None:
@@ -160,3 +161,28 @@ def _ensure_columns(
         if not column_name.replace("_", "").isalnum():
             raise ValueError(f"Invalid column name: {column_name}")
         conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_sql}")  # nosec B608: table_name and column_name validated above
+
+
+def _migrate_user_api_keys(conn: sqlite3.Connection) -> None:
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='user_api_keys'"
+    ).fetchall()
+    if rows:
+        return
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS user_api_keys (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            provider TEXT NOT NULL,
+            encrypted_key TEXT NOT NULL,
+            label TEXT NOT NULL DEFAULT '',
+            enabled INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_user_api_keys_provider ON user_api_keys(provider);"
+    )
+    conn.commit()

--- a/app/db.py
+++ b/app/db.py
@@ -189,6 +189,7 @@ def _migrate_user_api_keys(conn: sqlite3.Connection) -> None:
     index_rows = conn.execute(
         "PRAGMA index_list('user_api_keys')"
     ).fetchall()
+    # PRAGMA index_list returns (seq, name, unique, origin, partial)
     has_unique = any(row[2] == 1 for row in index_rows)
     if has_unique:
         return

--- a/app/db.py
+++ b/app/db.py
@@ -186,10 +186,11 @@ def _migrate_user_api_keys(conn: sqlite3.Connection) -> None:
         )
         conn.commit()
         return
-    unique_rows = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='user_api_keys' AND sql LIKE '%UNIQUE%'"
+    index_rows = conn.execute(
+        "PRAGMA index_list('user_api_keys')"
     ).fetchall()
-    if unique_rows:
+    has_unique = any(row[2] == 1 for row in index_rows)
+    if has_unique:
         return
     conn.execute(
         """

--- a/app/db.py
+++ b/app/db.py
@@ -167,11 +167,33 @@ def _migrate_user_api_keys(conn: sqlite3.Connection) -> None:
     rows = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='user_api_keys'"
     ).fetchall()
-    if rows:
+    if not rows:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS user_api_keys (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                provider TEXT NOT NULL UNIQUE,
+                encrypted_key TEXT NOT NULL,
+                label TEXT NOT NULL DEFAULT '',
+                enabled INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_user_api_keys_provider ON user_api_keys(provider);"
+        )
+        conn.commit()
+        return
+    unique_rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='user_api_keys' AND sql LIKE '%UNIQUE%'"
+    ).fetchall()
+    if unique_rows:
         return
     conn.execute(
         """
-        CREATE TABLE IF NOT EXISTS user_api_keys (
+        CREATE TABLE user_api_keys_new (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             provider TEXT NOT NULL UNIQUE,
             encrypted_key TEXT NOT NULL,
@@ -182,6 +204,11 @@ def _migrate_user_api_keys(conn: sqlite3.Connection) -> None:
         )
         """
     )
+    conn.execute(
+        "INSERT OR IGNORE INTO user_api_keys_new SELECT * FROM user_api_keys"
+    )
+    conn.execute("DROP TABLE user_api_keys")
+    conn.execute("ALTER TABLE user_api_keys_new RENAME TO user_api_keys")
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_user_api_keys_provider ON user_api_keys(provider);"
     )

--- a/app/db.py
+++ b/app/db.py
@@ -173,7 +173,7 @@ def _migrate_user_api_keys(conn: sqlite3.Connection) -> None:
         """
         CREATE TABLE IF NOT EXISTS user_api_keys (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            provider TEXT NOT NULL,
+            provider TEXT NOT NULL UNIQUE,
             encrypted_key TEXT NOT NULL,
             label TEXT NOT NULL DEFAULT '',
             enabled INTEGER NOT NULL DEFAULT 1,

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from app.db import init_db
 from app.routes.github import router as github_router
 from app.routes.hooks import router as hooks_router
 from app.routes.web import router as web_router
+from app.routes.byok import router as byok_router
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ app.state.templates = templates
 app.include_router(hooks_router)
 app.include_router(github_router)
 app.include_router(web_router)
+app.include_router(byok_router)
 
 
 @app.get("/healthz")

--- a/app/models.py
+++ b/app/models.py
@@ -126,6 +126,21 @@ CREATE TABLE IF NOT EXISTS app_config_audit_log (
 )
 
 
+USER_API_KEYS_TABLE = TableDef(
+    name="user_api_keys",
+    create_sql="""
+CREATE TABLE IF NOT EXISTS user_api_keys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider TEXT NOT NULL,
+    encrypted_key TEXT NOT NULL,
+    label TEXT NOT NULL DEFAULT '',
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+""".strip(),
+)
+
 SCHEMA_STATEMENTS = [
     SESSIONS_TABLE.create_sql,
     PULL_REQUESTS_TABLE.create_sql,
@@ -133,6 +148,7 @@ SCHEMA_STATEMENTS = [
     AUTOFIX_RUNS_TABLE.create_sql,
     APP_FEATURE_FLAGS_TABLE.create_sql,
     APP_CONFIG_AUDIT_LOG_TABLE.create_sql,
+    USER_API_KEYS_TABLE.create_sql,
     "CREATE INDEX IF NOT EXISTS idx_sessions_repo_branch ON sessions(repo, branch);",
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_pull_requests_repo_pr_number ON pull_requests(repo, pr_number);",
     "CREATE INDEX IF NOT EXISTS idx_review_events_repo_pr_number ON review_events(repo, pr_number);",
@@ -142,6 +158,7 @@ SCHEMA_STATEMENTS = [
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_autofix_runs_idempotency_key ON autofix_runs(idempotency_key);",
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_review_events_event_key ON review_events(event_key);",
     "CREATE INDEX IF NOT EXISTS idx_app_config_audit_log_key_created_at ON app_config_audit_log(key, created_at DESC);",
+    "CREATE INDEX IF NOT EXISTS idx_user_api_keys_provider ON user_api_keys(provider);",
 ]
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -131,7 +131,7 @@ USER_API_KEYS_TABLE = TableDef(
     create_sql="""
 CREATE TABLE IF NOT EXISTS user_api_keys (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    provider TEXT NOT NULL,
+    provider TEXT NOT NULL UNIQUE,
     encrypted_key TEXT NOT NULL,
     label TEXT NOT NULL DEFAULT '',
     enabled INTEGER NOT NULL DEFAULT 1,

--- a/app/routes/byok.py
+++ b/app/routes/byok.py
@@ -29,10 +29,7 @@ async def _verify_byok_admin(request: Request) -> None:
     settings = get_settings()
     admin_token = settings.byok_admin_token
     if not admin_token:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="BYOK admin token not configured",
-        )
+        return
     auth = request.headers.get("Authorization", "")
     if auth.startswith("Bearer "):
         token = auth[len("Bearer "):]
@@ -45,14 +42,40 @@ async def _verify_byok_admin(request: Request) -> None:
         )
 
 
-@router.get("/byok", response_class=HTMLResponse, dependencies=[Depends(_verify_byok_admin)])
+def _check_html_admin(request: Request) -> bool:
+    settings = get_settings()
+    admin_token = settings.byok_admin_token
+    if not admin_token:
+        return True
+    token = request.cookies.get("byok_admin_token", "")
+    return hmac.compare_digest(token, admin_token)
+
+
+def _html_auth_response(request: Request):
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="BYOK admin token required. Access via /byok?token=<your_token>",
+    )
+
+
+@router.get("/byok", response_class=HTMLResponse)
 async def byok_page(request: Request) -> HTMLResponse:
+    settings = get_settings()
+    admin_token = settings.byok_admin_token
+    if admin_token:
+        qp_token = request.query_params.get("token", "")
+        cookie_token = request.cookies.get("byok_admin_token", "")
+        qp_valid = hmac.compare_digest(qp_token, admin_token) if qp_token else False
+        cookie_valid = hmac.compare_digest(cookie_token, admin_token) if cookie_token else False
+        if not (cookie_valid or qp_valid):
+            _html_auth_response(request)
+
     templates = request.app.state.templates
     added = request.query_params.get("added") == "1"
     with connect_db() as conn:
         keys = list_api_keys(conn)
     message = "API key added successfully." if added else None
-    return templates.TemplateResponse(
+    response = templates.TemplateResponse(
         request=request,
         name="byok.html",
         context={
@@ -65,10 +88,19 @@ async def byok_page(request: Request) -> HTMLResponse:
             "form": {},
         },
     )
+    if admin_token:
+        qp_token = request.query_params.get("token", "")
+        if qp_token and hmac.compare_digest(qp_token, admin_token):
+            response.set_cookie(
+                "byok_admin_token", admin_token, httponly=True, max_age=86400
+            )
+    return response
 
 
-@router.post("/byok", response_class=HTMLResponse, dependencies=[Depends(_verify_byok_admin)])
+@router.post("/byok", response_class=HTMLResponse)
 async def byok_add_key(request: Request) -> HTMLResponse:
+    if not _check_html_admin(request):
+        _html_auth_response(request)
     templates = request.app.state.templates
     form = await request.form()
     provider = str(form.get("provider", "")).strip()
@@ -101,8 +133,10 @@ async def byok_add_key(request: Request) -> HTMLResponse:
     return RedirectResponse(url="/byok?added=1", status_code=303)
 
 
-@router.post("/byok/{key_id}/toggle", response_class=HTMLResponse, dependencies=[Depends(_verify_byok_admin)])
+@router.post("/byok/{key_id}/toggle", response_class=HTMLResponse)
 async def byok_toggle_key(request: Request, key_id: int) -> HTMLResponse:
+    if not _check_html_admin(request):
+        _html_auth_response(request)
     with connect_db() as conn:
         keys = list_api_keys(conn)
         current = next((k for k in keys if k.id == key_id), None)
@@ -112,8 +146,10 @@ async def byok_toggle_key(request: Request, key_id: int) -> HTMLResponse:
     return RedirectResponse(url="/byok", status_code=303)
 
 
-@router.post("/byok/{key_id}/delete", response_class=HTMLResponse, dependencies=[Depends(_verify_byok_admin)])
+@router.post("/byok/{key_id}/delete", response_class=HTMLResponse)
 async def byok_delete_key(request: Request, key_id: int) -> HTMLResponse:
+    if not _check_html_admin(request):
+        _html_auth_response(request)
     with connect_db() as conn:
         deleted = delete_api_key(conn, key_id)
     if not deleted:

--- a/app/routes/byok.py
+++ b/app/routes/byok.py
@@ -126,25 +126,7 @@ async def byok_add_key(request: Request) -> HTMLResponse:
     api_key = str(form.get("api_key", "")).strip()
     label = str(form.get("label", "")).strip()
 
-    try:
-        payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
-    except (ValueError, TypeError) as exc:
-        with connect_db() as conn:
-            keys = list_api_keys(conn)
-        return templates.TemplateResponse(
-            request=request,
-            name="byok.html",
-            context={
-                "request": request,
-                "title": "API Keys (BYOK)",
-                "keys": keys,
-                "providers": _PROVIDERS,
-                "message": str(exc),
-                "message_class": "",
-                "form": {"provider": provider, "label": label},
-            },
-            status_code=400,
-        )
+    payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
 
     try:
         with connect_db() as conn:
@@ -179,7 +161,9 @@ async def byok_toggle_key(request: Request, key_id: int) -> HTMLResponse:
         current = next((k for k in keys if k.id == key_id), None)
         if current is None:
             raise HTTPException(status_code=404, detail="Key not found")
-        toggle_api_key(conn, key_id, enabled=not current.enabled)
+        updated = toggle_api_key(conn, key_id, enabled=not current.enabled)
+        if not updated:
+            raise HTTPException(status_code=404, detail="Key not found")
     return RedirectResponse(url="/byok", status_code=303)
 
 
@@ -222,12 +206,7 @@ async def api_add_key(request: Request) -> JSONResponse:
     api_key = str(body.get("api_key", "")).strip()
     label = str(body.get("label", "")).strip()
 
-    try:
-        payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
-    except (ValueError, TypeError) as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
-        ) from exc
+    payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
 
     try:
         with connect_db() as conn:

--- a/app/routes/byok.py
+++ b/app/routes/byok.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hmac
+
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
@@ -27,20 +29,23 @@ async def _verify_byok_admin(request: Request) -> None:
     settings = get_settings()
     admin_token = settings.byok_admin_token
     if not admin_token:
-        return
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="BYOK admin token not configured",
+        )
     auth = request.headers.get("Authorization", "")
     if auth.startswith("Bearer "):
         token = auth[len("Bearer "):]
     else:
         token = auth
-    if token != admin_token:
+    if not hmac.compare_digest(token, admin_token):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or missing BYOK admin token",
         )
 
 
-@router.get("/byok", response_class=HTMLResponse)
+@router.get("/byok", response_class=HTMLResponse, dependencies=[Depends(_verify_byok_admin)])
 async def byok_page(request: Request) -> HTMLResponse:
     templates = request.app.state.templates
     added = request.query_params.get("added") == "1"
@@ -62,7 +67,7 @@ async def byok_page(request: Request) -> HTMLResponse:
     )
 
 
-@router.post("/byok", response_class=HTMLResponse)
+@router.post("/byok", response_class=HTMLResponse, dependencies=[Depends(_verify_byok_admin)])
 async def byok_add_key(request: Request) -> HTMLResponse:
     templates = request.app.state.templates
     form = await request.form()
@@ -70,35 +75,21 @@ async def byok_add_key(request: Request) -> HTMLResponse:
     api_key = str(form.get("api_key", "")).strip()
     label = str(form.get("label", "")).strip()
 
-    try:
-        payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
-    except (ValueError, TypeError) as exc:
-        return templates.TemplateResponse(
-            request=request,
-            name="byok.html",
-            context={
-                "request": request,
-                "title": "API Keys (BYOK)",
-                "keys": _load_keys(),
-                "providers": _PROVIDERS,
-                "message": f"Invalid input: {exc}",
-                "message_class": "",
-                "form": {"provider": provider, "label": label},
-            },
-            status_code=400,
-        )
+    payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
 
     try:
         with connect_db() as conn:
             add_api_key(conn, payload)
     except ValueError as exc:
+        with connect_db() as conn2:
+            keys = _load_keys(conn2)
         return templates.TemplateResponse(
             request=request,
             name="byok.html",
             context={
                 "request": request,
                 "title": "API Keys (BYOK)",
-                "keys": _load_keys(),
+                "keys": keys,
                 "providers": _PROVIDERS,
                 "message": str(exc),
                 "message_class": "",
@@ -110,18 +101,18 @@ async def byok_add_key(request: Request) -> HTMLResponse:
     return RedirectResponse(url="/byok?added=1", status_code=303)
 
 
-@router.post("/byok/{key_id}/toggle", response_class=HTMLResponse)
+@router.post("/byok/{key_id}/toggle", response_class=HTMLResponse, dependencies=[Depends(_verify_byok_admin)])
 async def byok_toggle_key(request: Request, key_id: int) -> HTMLResponse:
     with connect_db() as conn:
         keys = list_api_keys(conn)
         current = next((k for k in keys if k.id == key_id), None)
         if current is None:
             raise HTTPException(status_code=404, detail="Key not found")
-        updated = toggle_api_key(conn, key_id, enabled=not current.enabled)
+        toggle_api_key(conn, key_id, enabled=not current.enabled)
     return RedirectResponse(url="/byok", status_code=303)
 
 
-@router.post("/byok/{key_id}/delete", response_class=HTMLResponse)
+@router.post("/byok/{key_id}/delete", response_class=HTMLResponse, dependencies=[Depends(_verify_byok_admin)])
 async def byok_delete_key(request: Request, key_id: int) -> HTMLResponse:
     with connect_db() as conn:
         deleted = delete_api_key(conn, key_id)
@@ -158,12 +149,7 @@ async def api_add_key(request: Request) -> JSONResponse:
     api_key = str(body.get("api_key", "")).strip()
     label = str(body.get("label", "")).strip()
 
-    try:
-        payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
-    except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
-        ) from exc
+    payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
 
     try:
         with connect_db() as conn:
@@ -201,6 +187,5 @@ async def api_delete_key(key_id: int) -> JSONResponse:
     return JSONResponse({"ok": True})
 
 
-def _load_keys():
-    with connect_db() as conn:
-        return list_api_keys(conn)
+def _load_keys(conn):
+    return list_api_keys(conn)

--- a/app/routes/byok.py
+++ b/app/routes/byok.py
@@ -126,7 +126,25 @@ async def byok_add_key(request: Request) -> HTMLResponse:
     api_key = str(form.get("api_key", "")).strip()
     label = str(form.get("label", "")).strip()
 
-    payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
+    try:
+        payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
+    except (ValueError, TypeError) as exc:
+        with connect_db() as conn:
+            keys = list_api_keys(conn)
+        return templates.TemplateResponse(
+            request=request,
+            name="byok.html",
+            context={
+                "request": request,
+                "title": "API Keys (BYOK)",
+                "keys": keys,
+                "providers": _PROVIDERS,
+                "message": str(exc),
+                "message_class": "",
+                "form": {"provider": provider, "label": label},
+            },
+            status_code=400,
+        )
 
     try:
         with connect_db() as conn:
@@ -204,7 +222,12 @@ async def api_add_key(request: Request) -> JSONResponse:
     api_key = str(body.get("api_key", "")).strip()
     label = str(body.get("label", "")).strip()
 
-    payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
+    try:
+        payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
 
     try:
         with connect_db() as conn:

--- a/app/routes/byok.py
+++ b/app/routes/byok.py
@@ -15,6 +15,7 @@ from app.services.byok import (
     _PROVIDER_LABELS,
     add_api_key,
     delete_api_key,
+    flip_api_key_enabled,
     list_api_keys,
     toggle_api_key,
 )
@@ -157,11 +158,7 @@ async def byok_toggle_key(request: Request, key_id: int) -> HTMLResponse:
     if not _check_html_admin(request):
         _html_auth_response(request)
     with connect_db() as conn:
-        keys = list_api_keys(conn)
-        current = next((k for k in keys if k.id == key_id), None)
-        if current is None:
-            raise HTTPException(status_code=404, detail="Key not found")
-        updated = toggle_api_key(conn, key_id, enabled=not current.enabled)
+        updated = flip_api_key_enabled(conn, key_id)
         if not updated:
             raise HTTPException(status_code=404, detail="Key not found")
     return RedirectResponse(url="/byok", status_code=303)

--- a/app/routes/byok.py
+++ b/app/routes/byok.py
@@ -46,8 +46,13 @@ async def _verify_byok_admin(request: Request) -> None:
 
 def _token_hmac(token: str) -> str:
     settings = get_settings()
-    key = (settings.byok_encryption_key or settings.github_webhook_secret or "").encode()
-    return hashlib.sha256(key + b":" + token.encode()).hexdigest()
+    secret = settings.byok_encryption_key or settings.github_webhook_secret
+    if not secret:
+        raise RuntimeError(
+            "BYOK_ENCRYPTION_KEY or GITHUB_WEBHOOK_SECRET must be configured "
+            "for BYOK cookie authentication"
+        )
+    return hmac.new(secret.encode(), token.encode(), hashlib.sha256).hexdigest()
 
 
 def _check_html_admin(request: Request) -> bool:

--- a/app/routes/byok.py
+++ b/app/routes/byok.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+
+from app.db import connect_db
+from app.services.byok import (
+    SUPPORTED_PROVIDERS,
+    UserApiKeyCreatePayload,
+    _PROVIDER_LABELS,
+    add_api_key,
+    delete_api_key,
+    list_api_keys,
+    toggle_api_key,
+)
+
+router = APIRouter(tags=["byok"])
+
+_PROVIDERS = [
+    {"value": p, "label": _PROVIDER_LABELS.get(p, p)}
+    for p in SUPPORTED_PROVIDERS
+]
+
+
+@router.get("/byok", response_class=HTMLResponse)
+async def byok_page(request: Request) -> HTMLResponse:
+    templates = request.app.state.templates
+    with connect_db() as conn:
+        keys = list_api_keys(conn)
+    return templates.TemplateResponse(
+        request=request,
+        name="byok.html",
+        context={
+            "request": request,
+            "title": "API Keys (BYOK)",
+            "keys": keys,
+            "providers": _PROVIDERS,
+            "message": None,
+            "message_class": "ok",
+            "form": {},
+        },
+    )
+
+
+@router.post("/byok", response_class=HTMLResponse)
+async def byok_add_key(request: Request) -> HTMLResponse:
+    templates = request.app.state.templates
+    form = await request.form()
+    provider = str(form.get("provider", "")).strip()
+    api_key = str(form.get("api_key", "")).strip()
+    label = str(form.get("label", "")).strip()
+
+    try:
+        payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
+    except Exception:
+        return templates.TemplateResponse(
+            request=request,
+            name="byok.html",
+            context={
+                "request": request,
+                "title": "API Keys (BYOK)",
+                "keys": _load_keys(),
+                "providers": _PROVIDERS,
+                "message": "Invalid input.",
+                "message_class": "",
+                "form": {"provider": provider, "label": label},
+            },
+            status_code=400,
+        )
+
+    try:
+        with connect_db() as conn:
+            add_api_key(conn, payload)
+    except ValueError as exc:
+        return templates.TemplateResponse(
+            request=request,
+            name="byok.html",
+            context={
+                "request": request,
+                "title": "API Keys (BYOK)",
+                "keys": _load_keys(),
+                "providers": _PROVIDERS,
+                "message": str(exc),
+                "message_class": "",
+                "form": {"provider": provider, "label": label},
+            },
+            status_code=400,
+        )
+
+    return RedirectResponse(url="/byok?added=1", status_code=303)
+
+
+@router.post("/byok/{key_id}/toggle", response_class=HTMLResponse)
+async def byok_toggle_key(request: Request, key_id: int) -> HTMLResponse:
+    form = await request.form()
+    enabled = form.get("enabled") != "false"
+    with connect_db() as conn:
+        updated = toggle_api_key(conn, key_id, enabled=not enabled)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Key not found")
+    return RedirectResponse(url="/byok", status_code=303)
+
+
+@router.post("/byok/{key_id}/delete", response_class=HTMLResponse)
+async def byok_delete_key(request: Request, key_id: int) -> HTMLResponse:
+    with connect_db() as conn:
+        deleted = delete_api_key(conn, key_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Key not found")
+    return RedirectResponse(url="/byok", status_code=303)
+
+
+@router.get("/api/byok/keys")
+async def api_list_keys() -> JSONResponse:
+    with connect_db() as conn:
+        keys = list_api_keys(conn)
+    return JSONResponse(
+        {
+            "keys": [
+                {
+                    "id": k.id,
+                    "provider": k.provider,
+                    "label": k.label,
+                    "masked_key": k.masked_key,
+                    "enabled": k.enabled,
+                    "created_at": k.created_at,
+                }
+                for k in keys
+            ]
+        }
+    )
+
+
+@router.post("/api/byok/keys")
+async def api_add_key(request: Request) -> JSONResponse:
+    body = await request.json()
+    provider = str(body.get("provider", "")).strip()
+    api_key = str(body.get("api_key", "")).strip()
+    label = str(body.get("label", "")).strip()
+
+    try:
+        payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+
+    try:
+        with connect_db() as conn:
+            entry = add_api_key(conn, payload)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "key": {
+                "id": entry.id,
+                "provider": entry.provider,
+                "label": entry.label,
+                "masked_key": entry.masked_key,
+                "enabled": entry.enabled,
+            },
+        },
+        status_code=201,
+    )
+
+
+@router.delete("/api/byok/keys/{key_id}")
+async def api_delete_key(key_id: int) -> JSONResponse:
+    with connect_db() as conn:
+        deleted = delete_api_key(conn, key_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Key not found")
+    return JSONResponse({"ok": True})
+
+
+def _load_keys():
+    with connect_db() as conn:
+        return list_api_keys(conn)

--- a/app/routes/byok.py
+++ b/app/routes/byok.py
@@ -110,7 +110,7 @@ async def byok_page(request: Request) -> HTMLResponse:
                 _token_hmac(admin_token),
                 httponly=True,
                 max_age=86400,
-                secure=True,
+                secure=request.url.scheme == "https",
                 samesite="Lax",
             )
     return response
@@ -126,32 +126,14 @@ async def byok_add_key(request: Request) -> HTMLResponse:
     api_key = str(form.get("api_key", "")).strip()
     label = str(form.get("label", "")).strip()
 
-    try:
-        payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
-    except (ValueError, TypeError) as exc:
-        with connect_db() as conn2:
-            keys = _load_keys(conn2)
-        return templates.TemplateResponse(
-            request=request,
-            name="byok.html",
-            context={
-                "request": request,
-                "title": "API Keys (BYOK)",
-                "keys": keys,
-                "providers": _PROVIDERS,
-                "message": str(exc),
-                "message_class": "",
-                "form": {"provider": provider, "label": label},
-            },
-            status_code=400,
-        )
+    payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
 
     try:
         with connect_db() as conn:
             add_api_key(conn, payload)
     except ValueError as exc:
         with connect_db() as conn2:
-            keys = _load_keys(conn2)
+            keys = list_api_keys(conn2)
         return templates.TemplateResponse(
             request=request,
             name="byok.html",
@@ -222,12 +204,7 @@ async def api_add_key(request: Request) -> JSONResponse:
     api_key = str(body.get("api_key", "")).strip()
     label = str(body.get("label", "")).strip()
 
-    try:
-        payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
-    except (ValueError, TypeError) as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
-        ) from exc
+    payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
 
     try:
         with connect_db() as conn:
@@ -264,6 +241,3 @@ async def api_delete_key(key_id: int) -> JSONResponse:
         raise HTTPException(status_code=404, detail="Key not found")
     return JSONResponse({"ok": True})
 
-
-def _load_keys(conn):
-    return list_api_keys(conn)

--- a/app/routes/byok.py
+++ b/app/routes/byok.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import hmac
+from typing import NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
@@ -42,16 +44,23 @@ async def _verify_byok_admin(request: Request) -> None:
         )
 
 
+def _token_hmac(token: str) -> str:
+    settings = get_settings()
+    key = (settings.byok_encryption_key or settings.github_webhook_secret or "").encode()
+    return hashlib.sha256(key + b":" + token.encode()).hexdigest()
+
+
 def _check_html_admin(request: Request) -> bool:
     settings = get_settings()
     admin_token = settings.byok_admin_token
     if not admin_token:
         return True
-    token = request.cookies.get("byok_admin_token", "")
-    return hmac.compare_digest(token, admin_token)
+    cookie_val = request.cookies.get("byok_admin_token", "")
+    expected = _token_hmac(admin_token)
+    return hmac.compare_digest(cookie_val, expected)
 
 
-def _html_auth_response(request: Request):
+def _html_auth_response(request: Request) -> NoReturn:
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="BYOK admin token required. Access via /byok?token=<your_token>",
@@ -92,7 +101,12 @@ async def byok_page(request: Request) -> HTMLResponse:
         qp_token = request.query_params.get("token", "")
         if qp_token and hmac.compare_digest(qp_token, admin_token):
             response.set_cookie(
-                "byok_admin_token", admin_token, httponly=True, max_age=86400
+                "byok_admin_token",
+                _token_hmac(admin_token),
+                httponly=True,
+                max_age=86400,
+                secure=True,
+                samesite="Lax",
             )
     return response
 
@@ -107,7 +121,25 @@ async def byok_add_key(request: Request) -> HTMLResponse:
     api_key = str(form.get("api_key", "")).strip()
     label = str(form.get("label", "")).strip()
 
-    payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
+    try:
+        payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
+    except (ValueError, TypeError) as exc:
+        with connect_db() as conn2:
+            keys = _load_keys(conn2)
+        return templates.TemplateResponse(
+            request=request,
+            name="byok.html",
+            context={
+                "request": request,
+                "title": "API Keys (BYOK)",
+                "keys": keys,
+                "providers": _PROVIDERS,
+                "message": str(exc),
+                "message_class": "",
+                "form": {"provider": provider, "label": label},
+            },
+            status_code=400,
+        )
 
     try:
         with connect_db() as conn:
@@ -185,7 +217,12 @@ async def api_add_key(request: Request) -> JSONResponse:
     api_key = str(body.get("api_key", "")).strip()
     label = str(body.get("label", "")).strip()
 
-    payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
+    try:
+        payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
 
     try:
         with connect_db() as conn:

--- a/app/routes/byok.py
+++ b/app/routes/byok.py
@@ -17,7 +17,6 @@ from app.services.byok import (
     delete_api_key,
     flip_api_key_enabled,
     list_api_keys,
-    toggle_api_key,
 )
 
 router = APIRouter(tags=["byok"])

--- a/app/routes/byok.py
+++ b/app/routes/byok.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
+from app.config import get_settings
 from app.db import connect_db
 from app.services.byok import (
     SUPPORTED_PROVIDERS,
@@ -22,11 +23,30 @@ _PROVIDERS = [
 ]
 
 
+async def _verify_byok_admin(request: Request) -> None:
+    settings = get_settings()
+    admin_token = settings.byok_admin_token
+    if not admin_token:
+        return
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer "):
+        token = auth[len("Bearer "):]
+    else:
+        token = auth
+    if token != admin_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing BYOK admin token",
+        )
+
+
 @router.get("/byok", response_class=HTMLResponse)
 async def byok_page(request: Request) -> HTMLResponse:
     templates = request.app.state.templates
+    added = request.query_params.get("added") == "1"
     with connect_db() as conn:
         keys = list_api_keys(conn)
+    message = "API key added successfully." if added else None
     return templates.TemplateResponse(
         request=request,
         name="byok.html",
@@ -35,8 +55,8 @@ async def byok_page(request: Request) -> HTMLResponse:
             "title": "API Keys (BYOK)",
             "keys": keys,
             "providers": _PROVIDERS,
-            "message": None,
-            "message_class": "ok",
+            "message": message,
+            "message_class": "ok" if added else "",
             "form": {},
         },
     )
@@ -52,7 +72,7 @@ async def byok_add_key(request: Request) -> HTMLResponse:
 
     try:
         payload = UserApiKeyCreatePayload(provider=provider, api_key=api_key, label=label)
-    except Exception:
+    except (ValueError, TypeError) as exc:
         return templates.TemplateResponse(
             request=request,
             name="byok.html",
@@ -61,7 +81,7 @@ async def byok_add_key(request: Request) -> HTMLResponse:
                 "title": "API Keys (BYOK)",
                 "keys": _load_keys(),
                 "providers": _PROVIDERS,
-                "message": "Invalid input.",
+                "message": f"Invalid input: {exc}",
                 "message_class": "",
                 "form": {"provider": provider, "label": label},
             },
@@ -92,12 +112,12 @@ async def byok_add_key(request: Request) -> HTMLResponse:
 
 @router.post("/byok/{key_id}/toggle", response_class=HTMLResponse)
 async def byok_toggle_key(request: Request, key_id: int) -> HTMLResponse:
-    form = await request.form()
-    enabled = form.get("enabled") != "false"
     with connect_db() as conn:
-        updated = toggle_api_key(conn, key_id, enabled=not enabled)
-    if not updated:
-        raise HTTPException(status_code=404, detail="Key not found")
+        keys = list_api_keys(conn)
+        current = next((k for k in keys if k.id == key_id), None)
+        if current is None:
+            raise HTTPException(status_code=404, detail="Key not found")
+        updated = toggle_api_key(conn, key_id, enabled=not current.enabled)
     return RedirectResponse(url="/byok", status_code=303)
 
 
@@ -110,7 +130,7 @@ async def byok_delete_key(request: Request, key_id: int) -> HTMLResponse:
     return RedirectResponse(url="/byok", status_code=303)
 
 
-@router.get("/api/byok/keys")
+@router.get("/api/byok/keys", dependencies=[Depends(_verify_byok_admin)])
 async def api_list_keys() -> JSONResponse:
     with connect_db() as conn:
         keys = list_api_keys(conn)
@@ -131,7 +151,7 @@ async def api_list_keys() -> JSONResponse:
     )
 
 
-@router.post("/api/byok/keys")
+@router.post("/api/byok/keys", dependencies=[Depends(_verify_byok_admin)])
 async def api_add_key(request: Request) -> JSONResponse:
     body = await request.json()
     provider = str(body.get("provider", "")).strip()
@@ -168,7 +188,11 @@ async def api_add_key(request: Request) -> JSONResponse:
     )
 
 
-@router.delete("/api/byok/keys/{key_id}")
+@router.delete(
+    "/api/byok/keys/{key_id}",
+    response_class=JSONResponse,
+    dependencies=[Depends(_verify_byok_admin)],
+)
 async def api_delete_key(key_id: int) -> JSONResponse:
     with connect_db() as conn:
         deleted = delete_api_key(conn, key_id)

--- a/app/routes/byok.py
+++ b/app/routes/byok.py
@@ -75,7 +75,7 @@ async def byok_page(request: Request) -> HTMLResponse:
         qp_token = request.query_params.get("token", "")
         cookie_token = request.cookies.get("byok_admin_token", "")
         qp_valid = hmac.compare_digest(qp_token, admin_token) if qp_token else False
-        cookie_valid = hmac.compare_digest(cookie_token, admin_token) if cookie_token else False
+        cookie_valid = hmac.compare_digest(cookie_token, _token_hmac(admin_token)) if cookie_token else False
         if not (cookie_valid or qp_valid):
             _html_auth_response(request)
 

--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -2727,7 +2727,7 @@ def _build_claude_agent_environment(
         pr_number=pr_number,
         normalized_review=normalized_review,
     )
-    _byok = dict(byok_overrides) if byok_overrides else {}
+    _byok = byok_overrides or {}
     normalized_provider = str(provider).strip().lower()
     normalized_base_url = str(base_url).strip()
     normalized_model = str(model).strip()

--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -2754,6 +2754,10 @@ def _build_claude_agent_environment(
         if openrouter_key:
             env["ANTHROPIC_AUTH_TOKEN"] = openrouter_key
         env["ANTHROPIC_API_KEY"] = ""
+    else:
+        ant_key = _byok.get("ANTHROPIC_API_KEY")
+        if ant_key:
+            env["ANTHROPIC_API_KEY"] = ant_key
 
     if normalized_base_url:
         env["ANTHROPIC_BASE_URL"] = normalized_base_url

--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -57,6 +57,7 @@ from app.services.queue import (
 from app.services.retry import RetryConfig, schedule_retry
 from app.services.run_hints import ExecutionHints, parse_execution_hints
 from app.services.runtime_settings import RuntimeSettings, resolve_runtime_settings
+from app.services.byok import build_byok_env_overrides
 from app.services.task_source import (
     build_task_pull_request_body,
     build_task_pull_request_title,
@@ -786,6 +787,7 @@ def run_once(
                         )
 
         new_failure_results: list[dict[str, Any]] = []
+        byok_overrides = build_byok_env_overrides(conn)
         for attempt in range(1, MAX_CHECK_FEEDBACK_ATTEMPTS + 1):
             operator_hints = get_run_operator_hints(conn, run_id)
             execution_hints = parse_execution_hints(operator_hints)
@@ -844,6 +846,7 @@ def run_once(
                     ),
                     on_log_line=logger.append,
                     should_cancel=lambda: is_run_cancel_requested(conn, run_id),
+                    byok_overrides=byok_overrides,
                 )
             )
             logger.append(f"agent_mode={used_agent_mode or 'unknown'}")
@@ -1517,6 +1520,7 @@ def _execute_agent_sdks(
     claude_agent_command_timeout_seconds: int,
     on_log_line: Callable[[str], None] | None = None,
     should_cancel: Callable[[], bool] | None = None,
+    byok_overrides: Mapping[str, str] | None = None,
 ) -> tuple[bool, str | None, str | None, str | None]:
     last_error_code: str | None = None
     last_error_message: str | None = None
@@ -1607,6 +1611,7 @@ def _execute_agent_sdks(
             if should_cancel is not None:
                 claude_kwargs["should_cancel"] = should_cancel
             claude_kwargs["normalized_review"] = normalized_review
+            claude_kwargs["byok_overrides"] = byok_overrides
             claude_ok, claude_message, claude_error_code = _run_claude_agent(
                 **claude_kwargs,
             )
@@ -1703,6 +1708,7 @@ def _run_claude_agent(
     timeout_seconds: int,
     on_log_line: Callable[[str], None] | None = None,
     should_cancel: Callable[[], bool] | None = None,
+    byok_overrides: Mapping[str, str] | None = None,
 ) -> tuple[bool, str, str | None]:
     if runtime == "docker":
         return _run_claude_container_command(
@@ -1722,6 +1728,7 @@ def _run_claude_agent(
             failure_code=CLAUDE_FAILURE_CODE_COMMAND,
             on_log_line=on_log_line,
             should_cancel=should_cancel,
+            byok_overrides=byok_overrides,
         )
     return _run_claude_stream_command(
         workspace=workspace,
@@ -1739,6 +1746,7 @@ def _run_claude_agent(
         failure_code=CLAUDE_FAILURE_CODE_COMMAND,
         on_log_line=on_log_line,
         should_cancel=should_cancel,
+        byok_overrides=byok_overrides,
     )
 
 
@@ -1760,6 +1768,7 @@ def _run_claude_container_command(
     failure_code: str,
     on_log_line: Callable[[str], None] | None = None,
     should_cancel: Callable[[], bool] | None = None,
+    byok_overrides: Mapping[str, str] | None = None,
 ) -> tuple[bool, str, str | None]:
     normalized_command = command.strip()
     if not normalized_command:
@@ -1790,6 +1799,7 @@ def _run_claude_container_command(
         provider=provider,
         base_url=base_url,
         model=model,
+        byok_overrides=byok_overrides,
     )
     argv = _build_claude_container_command_argv(
         workspace=workspace,
@@ -1834,6 +1844,7 @@ def _run_claude_stream_command(
     failure_code: str,
     on_log_line: Callable[[str], None] | None = None,
     should_cancel: Callable[[], bool] | None = None,
+    byok_overrides: Mapping[str, str] | None = None,
 ) -> tuple[bool, str, str | None]:
     normalized_command = command.strip()
     if not normalized_command:
@@ -1872,6 +1883,7 @@ def _run_claude_stream_command(
             provider=provider,
             base_url=base_url,
             model=model,
+            byok_overrides=byok_overrides,
         ),
     )
 
@@ -2111,6 +2123,7 @@ def _build_claude_container_environment(
     provider: str,
     base_url: str,
     model: str,
+    byok_overrides: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
     env = _build_claude_agent_environment(
         repo=repo,
@@ -2120,6 +2133,7 @@ def _build_claude_container_environment(
         provider=provider,
         base_url=base_url,
         model=model,
+        byok_overrides=byok_overrides,
     )
     env["HOME"] = "/tmp/claude-home"
     env["XDG_CONFIG_HOME"] = "/tmp/claude-home/.config"
@@ -2705,6 +2719,7 @@ def _build_claude_agent_environment(
     provider: str,
     base_url: str,
     model: str,
+    byok_overrides: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
     env = _build_agent_env(
         run_id=run_id,
@@ -2712,6 +2727,7 @@ def _build_claude_agent_environment(
         pr_number=pr_number,
         normalized_review=normalized_review,
     )
+    _byok = dict(byok_overrides) if byok_overrides else {}
     normalized_provider = str(provider).strip().lower()
     normalized_base_url = str(base_url).strip()
     normalized_model = str(model).strip()
@@ -2719,7 +2735,7 @@ def _build_claude_agent_environment(
     if normalized_provider == "zhipu":
         env.pop("ANTHROPIC_MODEL", None)
         env.pop("ANTHROPIC_SMALL_FAST_MODEL", None)
-        zhipu_key = str(os.environ.get("ZHIPU_API_KEY", "")).strip()
+        zhipu_key = _byok.get("ZHIPU_API_KEY") or str(os.environ.get("ZHIPU_API_KEY", "")).strip()
         if zhipu_key:
             env["ANTHROPIC_AUTH_TOKEN"] = zhipu_key
             env["ANTHROPIC_API_KEY"] = zhipu_key
@@ -2729,12 +2745,12 @@ def _build_claude_agent_environment(
         env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = "glm-4.7"
         env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = normalized_model or "glm-5"
     elif normalized_provider == "deepseek":
-        deepseek_key = str(os.environ.get("DEEPSEEK_API_KEY", "")).strip()
+        deepseek_key = _byok.get("DEEPSEEK_API_KEY") or str(os.environ.get("DEEPSEEK_API_KEY", "")).strip()
         if deepseek_key:
             env["ANTHROPIC_AUTH_TOKEN"] = deepseek_key
             env["ANTHROPIC_API_KEY"] = deepseek_key
     elif normalized_provider:
-        openrouter_key = str(os.environ.get("OPENROUTER_API_KEY", "")).strip()
+        openrouter_key = _byok.get("OPENROUTER_API_KEY") or str(os.environ.get("OPENROUTER_API_KEY", "")).strip()
         if openrouter_key:
             env["ANTHROPIC_AUTH_TOKEN"] = openrouter_key
         env["ANTHROPIC_API_KEY"] = ""

--- a/app/services/ai_client.py
+++ b/app/services/ai_client.py
@@ -71,15 +71,17 @@ def generate_fix(
     prompt: str,
     workspace_dir: str,
     normalized_review: Mapping[str, Any],
+    byok_overrides: Mapping[str, str] | None = None,
 ) -> FixPlan:
     settings = get_settings()
     provider = settings.ai_provider.strip().lower()
     request_prompt = _build_request_prompt(prompt, workspace_dir, normalized_review)
+    _byok = dict(byok_overrides) if byok_overrides else {}
 
     if provider == "anthropic":
-        text = _call_anthropic(request_prompt)
+        text = _call_anthropic(request_prompt, byok_overrides=_byok)
     elif provider == "openai":
-        text = _call_openai(request_prompt)
+        text = _call_openai(request_prompt, byok_overrides=_byok)
     else:
         raise AIConfigError(
             f"unsupported AI_PROVIDER '{settings.ai_provider or 'unset'}'"
@@ -185,9 +187,10 @@ def _resolve_context_path(workspace: Path, rel_path: str) -> Path | None:
     return candidate
 
 
-def _call_anthropic(request_prompt: str) -> str:
+def _call_anthropic(request_prompt: str, *, byok_overrides: Mapping[str, str] | None = None) -> str:
     settings = get_settings()
-    if not settings.anthropic_api_key:
+    api_key = (byok_overrides or {}).get("ANTHROPIC_API_KEY") or settings.anthropic_api_key
+    if not api_key:
         raise AIConfigError("ANTHROPIC_API_KEY is required when AI_PROVIDER=anthropic")
 
     payload = {
@@ -197,7 +200,7 @@ def _call_anthropic(request_prompt: str) -> str:
         "messages": [{"role": "user", "content": request_prompt}],
     }
     headers = {
-        "x-api-key": settings.anthropic_api_key,
+        "x-api-key": api_key,
         "anthropic-version": "2023-06-01",
         "content-type": "application/json",
     }
@@ -219,9 +222,10 @@ def _call_anthropic(request_prompt: str) -> str:
     return text
 
 
-def _call_openai(request_prompt: str) -> str:
+def _call_openai(request_prompt: str, *, byok_overrides: Mapping[str, str] | None = None) -> str:
     settings = get_settings()
-    if not settings.openai_api_key:
+    api_key = (byok_overrides or {}).get("OPENAI_API_KEY") or settings.openai_api_key
+    if not api_key:
         raise AIConfigError("OPENAI_API_KEY is required when AI_PROVIDER=openai")
 
     payload = {
@@ -237,7 +241,7 @@ def _call_openai(request_prompt: str) -> str:
         ],
     }
     headers = {
-        "Authorization": f"Bearer {settings.openai_api_key}",
+        "Authorization": f"Bearer {api_key}",
         "content-type": "application/json",
     }
     data = _post_json(

--- a/app/services/ai_client.py
+++ b/app/services/ai_client.py
@@ -73,10 +73,17 @@ def generate_fix(
     normalized_review: Mapping[str, Any],
     byok_overrides: Mapping[str, str] | None = None,
 ) -> FixPlan:
+    """Generate a fix plan using the configured AI provider.
+
+    ``byok_overrides`` allows callers to inject user-provided API keys
+    (from the BYOK subsystem) that take precedence over the global
+    configuration.  Pass the result of ``build_byok_env_overrides``
+    when available.
+    """
     settings = get_settings()
     provider = settings.ai_provider.strip().lower()
     request_prompt = _build_request_prompt(prompt, workspace_dir, normalized_review)
-    _byok = dict(byok_overrides) if byok_overrides else {}
+    _byok = byok_overrides or {}
 
     if provider == "anthropic":
         text = _call_anthropic(request_prompt, byok_overrides=_byok)

--- a/app/services/byok.py
+++ b/app/services/byok.py
@@ -40,9 +40,10 @@ _PROVIDER_ENV_MAP = {
 
 @functools.lru_cache(maxsize=1)
 def _make_fernet(secret: str) -> Fernet:
-    """Cache keyed on *secret* — changing the encryption secret at runtime
-    requires a process restart; previously encrypted data will not be
-    decryptable with a different secret."""
+    """Cache keyed on *secret* — when the secret changes the lru_cache will
+    transparently cache a new Fernet instance, but data encrypted with the
+    previous secret will no longer be decryptable.  Switching secrets in
+    production requires re-encrypting all stored keys first."""
     key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode("utf-8")).digest())
     return Fernet(key)
 

--- a/app/services/byok.py
+++ b/app/services/byok.py
@@ -5,7 +5,6 @@ import hashlib
 import logging
 import sqlite3
 from dataclasses import dataclass
-from typing import Any
 
 from cryptography.fernet import Fernet, InvalidToken
 
@@ -40,10 +39,11 @@ _PROVIDER_ENV_MAP = {
 
 def _get_fernet() -> Fernet:
     settings = get_settings()
-    secret = settings.github_webhook_secret
+    secret = settings.byok_encryption_key or settings.github_webhook_secret
     if not secret:
         raise RuntimeError(
-            "GITHUB_WEBHOOK_SECRET must be configured for BYOK encryption"
+            "BYOK_ENCRYPTION_KEY or GITHUB_WEBHOOK_SECRET must be configured "
+            "for BYOK encryption"
         )
     key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode("utf-8")).digest())
     return Fernet(key)
@@ -93,7 +93,8 @@ def list_api_keys(conn: sqlite3.Connection) -> list[UserApiKeyEntry]:
     for row in rows:
         try:
             plain = _decrypt(str(row["encrypted_key"]))
-        except (InvalidToken, Exception):
+        except InvalidToken:
+            _LOG.warning("failed to decrypt key id=%s", row["id"])
             plain = ""
         entries.append(
             UserApiKeyEntry(
@@ -122,6 +123,15 @@ def add_api_key(
     api_key = payload.api_key.strip()
     if not api_key:
         raise ValueError("API key must not be empty")
+    existing = conn.execute(
+        "SELECT id FROM user_api_keys WHERE provider = ? LIMIT 1",
+        (provider,),
+    ).fetchone()
+    if existing:
+        conn.execute(
+            "DELETE FROM user_api_keys WHERE provider = ?",
+            (provider,),
+        )
     encrypted = _encrypt(api_key)
     label = payload.label.strip() or _PROVIDER_LABELS.get(provider, provider)
     cursor = conn.execute(

--- a/app/services/byok.py
+++ b/app/services/byok.py
@@ -198,7 +198,7 @@ def resolve_api_key(conn: sqlite3.Connection, provider: str) -> str | None:
         return None
     try:
         return _decrypt(str(row["encrypted_key"]))
-    except Exception:
+    except InvalidToken:
         _LOG.warning("failed to decrypt BYOK key for provider %s", provider)
         return None
 
@@ -218,7 +218,7 @@ def resolve_all_api_keys(conn: sqlite3.Connection) -> dict[str, str]:
             continue
         try:
             result[provider] = _decrypt(str(row["encrypted_key"]))
-        except Exception:
+        except InvalidToken:
             _LOG.warning("failed to decrypt BYOK key for provider %s", provider)
     return result
 

--- a/app/services/byok.py
+++ b/app/services/byok.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import base64
 import hashlib
 import logging
-import os
 import sqlite3
 from dataclasses import dataclass
 from typing import Any
+
+from cryptography.fernet import Fernet, InvalidToken
 
 from app.config import get_settings
 
@@ -37,29 +38,23 @@ _PROVIDER_ENV_MAP = {
 }
 
 
-def _get_encryption_key() -> bytes:
+def _get_fernet() -> Fernet:
     settings = get_settings()
-    secret = settings.github_webhook_secret or "software-factory-byok-default"
-    return hashlib.sha256(secret.encode("utf-8")).digest()
+    secret = settings.github_webhook_secret
+    if not secret:
+        raise RuntimeError(
+            "GITHUB_WEBHOOK_SECRET must be configured for BYOK encryption"
+        )
+    key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode("utf-8")).digest())
+    return Fernet(key)
 
 
 def _encrypt(plaintext: str) -> str:
-    key = _get_encryption_key()
-    raw = plaintext.encode("utf-8")
-    encrypted = bytes(a ^ b for a, b in zip(raw, _cycle_key(key, len(raw))))
-    return base64.b64encode(encrypted).decode("ascii")
+    return _get_fernet().encrypt(plaintext.encode("utf-8")).decode("ascii")
 
 
 def _decrypt(ciphertext: str) -> str:
-    key = _get_encryption_key()
-    raw = base64.b64decode(ciphertext)
-    decrypted = bytes(a ^ b for a, b in zip(raw, _cycle_key(key, len(raw))))
-    return decrypted.decode("utf-8")
-
-
-def _cycle_key(key: bytes, length: int) -> bytes:
-    full_repeats = length // len(key) + 1
-    return (key * full_repeats)[:length]
+    return _get_fernet().decrypt(ciphertext.encode("ascii")).decode("utf-8")
 
 
 def _mask_key(key: str) -> str:
@@ -98,7 +93,7 @@ def list_api_keys(conn: sqlite3.Connection) -> list[UserApiKeyEntry]:
     for row in rows:
         try:
             plain = _decrypt(str(row["encrypted_key"]))
-        except Exception:
+        except (InvalidToken, Exception):
             plain = ""
         entries.append(
             UserApiKeyEntry(

--- a/app/services/byok.py
+++ b/app/services/byok.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import functools
 import hashlib
 import logging
 import sqlite3
@@ -37,7 +38,10 @@ _PROVIDER_ENV_MAP = {
 }
 
 
-_fernet_cache: dict[str, Fernet] = {}
+@functools.lru_cache(maxsize=1)
+def _make_fernet(secret: str) -> Fernet:
+    key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode("utf-8")).digest())
+    return Fernet(key)
 
 
 def _get_fernet() -> Fernet:
@@ -48,10 +52,7 @@ def _get_fernet() -> Fernet:
             "BYOK_ENCRYPTION_KEY or GITHUB_WEBHOOK_SECRET must be configured "
             "for BYOK encryption"
         )
-    if secret not in _fernet_cache:
-        key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode("utf-8")).digest())
-        _fernet_cache[secret] = Fernet(key)
-    return _fernet_cache[secret]
+    return _make_fernet(secret)
 
 
 def _encrypt(plaintext: str) -> str:

--- a/app/services/byok.py
+++ b/app/services/byok.py
@@ -6,7 +6,7 @@ import logging
 import sqlite3
 from dataclasses import dataclass
 
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 
 from app.config import get_settings
 
@@ -93,8 +93,11 @@ def list_api_keys(conn: sqlite3.Connection) -> list[UserApiKeyEntry]:
     for row in rows:
         try:
             plain = _decrypt(str(row["encrypted_key"]))
-        except Exception:
+        except InvalidToken:
             _LOG.warning("failed to decrypt key id=%s", row["id"])
+            plain = ""
+        except Exception as e:
+            _LOG.error("unexpected error decrypting key id=%s: %s: %s", row["id"], type(e).__name__, e)
             plain = ""
         entries.append(
             UserApiKeyEntry(
@@ -189,8 +192,11 @@ def resolve_api_key(conn: sqlite3.Connection, provider: str) -> str | None:
         return None
     try:
         return _decrypt(str(row["encrypted_key"]))
-    except Exception:
+    except InvalidToken:
         _LOG.warning("failed to decrypt BYOK key for provider %s", provider)
+        return None
+    except Exception as e:
+        _LOG.error("unexpected error decrypting BYOK key for provider %s: %s: %s", provider, type(e).__name__, e)
         return None
 
 
@@ -209,8 +215,10 @@ def resolve_all_api_keys(conn: sqlite3.Connection) -> dict[str, str]:
             continue
         try:
             result[provider] = _decrypt(str(row["encrypted_key"]))
-        except Exception:
+        except InvalidToken:
             _LOG.warning("failed to decrypt BYOK key for provider %s", provider)
+        except Exception as e:
+            _LOG.error("unexpected error decrypting BYOK key for provider %s: %s: %s", provider, type(e).__name__, e)
     return result
 
 

--- a/app/services/byok.py
+++ b/app/services/byok.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import os
+import sqlite3
+from dataclasses import dataclass
+from typing import Any
+
+from app.config import get_settings
+
+_LOG = logging.getLogger(__name__)
+
+SUPPORTED_PROVIDERS = (
+    "anthropic",
+    "openai",
+    "zhipu",
+    "deepseek",
+    "openrouter",
+)
+
+_PROVIDER_LABELS = {
+    "anthropic": "Anthropic",
+    "openai": "OpenAI",
+    "zhipu": "ZhipuAI",
+    "deepseek": "DeepSeek",
+    "openrouter": "OpenRouter",
+}
+
+_PROVIDER_ENV_MAP = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "zhipu": "ZHIPU_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+}
+
+
+def _get_encryption_key() -> bytes:
+    settings = get_settings()
+    secret = settings.github_webhook_secret or "software-factory-byok-default"
+    return hashlib.sha256(secret.encode("utf-8")).digest()
+
+
+def _encrypt(plaintext: str) -> str:
+    key = _get_encryption_key()
+    raw = plaintext.encode("utf-8")
+    encrypted = bytes(a ^ b for a, b in zip(raw, _cycle_key(key, len(raw))))
+    return base64.b64encode(encrypted).decode("ascii")
+
+
+def _decrypt(ciphertext: str) -> str:
+    key = _get_encryption_key()
+    raw = base64.b64decode(ciphertext)
+    decrypted = bytes(a ^ b for a, b in zip(raw, _cycle_key(key, len(raw))))
+    return decrypted.decode("utf-8")
+
+
+def _cycle_key(key: bytes, length: int) -> bytes:
+    full_repeats = length // len(key) + 1
+    return (key * full_repeats)[:length]
+
+
+def _mask_key(key: str) -> str:
+    if len(key) <= 8:
+        return "****"
+    return key[:4] + "****" + key[-4:]
+
+
+@dataclass(frozen=True)
+class UserApiKeyEntry:
+    id: int
+    provider: str
+    label: str
+    masked_key: str
+    enabled: bool
+    created_at: str
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class UserApiKeyCreatePayload:
+    provider: str
+    api_key: str
+    label: str
+
+
+def list_api_keys(conn: sqlite3.Connection) -> list[UserApiKeyEntry]:
+    rows = conn.execute(
+        """
+        SELECT id, provider, encrypted_key, label, enabled, created_at, updated_at
+        FROM user_api_keys
+        ORDER BY provider, id
+        """
+    ).fetchall()
+    entries: list[UserApiKeyEntry] = []
+    for row in rows:
+        try:
+            plain = _decrypt(str(row["encrypted_key"]))
+        except Exception:
+            plain = ""
+        entries.append(
+            UserApiKeyEntry(
+                id=int(row["id"]),
+                provider=str(row["provider"]),
+                label=str(row["label"] or ""),
+                masked_key=_mask_key(plain),
+                enabled=bool(row["enabled"]),
+                created_at=str(row["created_at"]),
+                updated_at=str(row["updated_at"]),
+            )
+        )
+    return entries
+
+
+def add_api_key(
+    conn: sqlite3.Connection,
+    payload: UserApiKeyCreatePayload,
+) -> UserApiKeyEntry:
+    provider = payload.provider.strip().lower()
+    if provider not in SUPPORTED_PROVIDERS:
+        raise ValueError(
+            f"unsupported provider '{provider}'. "
+            f"Supported: {', '.join(SUPPORTED_PROVIDERS)}"
+        )
+    api_key = payload.api_key.strip()
+    if not api_key:
+        raise ValueError("API key must not be empty")
+    encrypted = _encrypt(api_key)
+    label = payload.label.strip() or _PROVIDER_LABELS.get(provider, provider)
+    cursor = conn.execute(
+        """
+        INSERT INTO user_api_keys (provider, encrypted_key, label, enabled)
+        VALUES (?, ?, ?, 1)
+        """,
+        (provider, encrypted, label),
+    )
+    conn.commit()
+    row_id = cursor.lastrowid
+    row = conn.execute(
+        """
+        SELECT id, provider, encrypted_key, label, enabled, created_at, updated_at
+        FROM user_api_keys WHERE id = ?
+        """,
+        (row_id,),
+    ).fetchone()
+    plain = _decrypt(str(row["encrypted_key"]))
+    return UserApiKeyEntry(
+        id=int(row["id"]),
+        provider=str(row["provider"]),
+        label=str(row["label"] or ""),
+        masked_key=_mask_key(plain),
+        enabled=bool(row["enabled"]),
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+    )
+
+
+def delete_api_key(conn: sqlite3.Connection, key_id: int) -> bool:
+    cursor = conn.execute(
+        "DELETE FROM user_api_keys WHERE id = ?",
+        (key_id,),
+    )
+    conn.commit()
+    return cursor.rowcount > 0
+
+
+def toggle_api_key(conn: sqlite3.Connection, key_id: int, *, enabled: bool) -> bool:
+    cursor = conn.execute(
+        """
+        UPDATE user_api_keys SET enabled = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?
+        """,
+        (1 if enabled else 0, key_id),
+    )
+    conn.commit()
+    return cursor.rowcount > 0
+
+
+def resolve_api_key(conn: sqlite3.Connection, provider: str) -> str | None:
+    provider = provider.strip().lower()
+    row = conn.execute(
+        """
+        SELECT encrypted_key FROM user_api_keys
+        WHERE provider = ? AND enabled = 1
+        ORDER BY id DESC
+        LIMIT 1
+        """,
+        (provider,),
+    ).fetchone()
+    if row is None:
+        return None
+    try:
+        return _decrypt(str(row["encrypted_key"]))
+    except Exception:
+        _LOG.warning("failed to decrypt BYOK key for provider %s", provider)
+        return None
+
+
+def resolve_all_api_keys(conn: sqlite3.Connection) -> dict[str, str]:
+    rows = conn.execute(
+        """
+        SELECT provider, encrypted_key FROM user_api_keys
+        WHERE enabled = 1
+        ORDER BY id DESC
+        """
+    ).fetchall()
+    result: dict[str, str] = {}
+    for row in rows:
+        provider = str(row["provider"]).strip().lower()
+        if provider in result:
+            continue
+        try:
+            result[provider] = _decrypt(str(row["encrypted_key"]))
+        except Exception:
+            _LOG.warning("failed to decrypt BYOK key for provider %s", provider)
+    return result
+
+
+def build_byok_env_overrides(conn: sqlite3.Connection) -> dict[str, str]:
+    byok_keys = resolve_all_api_keys(conn)
+    env_overrides: dict[str, str] = {}
+    for provider, api_key in byok_keys.items():
+        env_var = _PROVIDER_ENV_MAP.get(provider)
+        if env_var:
+            env_overrides[env_var] = api_key
+    return env_overrides

--- a/app/services/byok.py
+++ b/app/services/byok.py
@@ -37,6 +37,9 @@ _PROVIDER_ENV_MAP = {
 }
 
 
+_fernet_cache: dict[str, Fernet] = {}
+
+
 def _get_fernet() -> Fernet:
     settings = get_settings()
     secret = settings.byok_encryption_key or settings.github_webhook_secret
@@ -45,8 +48,10 @@ def _get_fernet() -> Fernet:
             "BYOK_ENCRYPTION_KEY or GITHUB_WEBHOOK_SECRET must be configured "
             "for BYOK encryption"
         )
-    key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode("utf-8")).digest())
-    return Fernet(key)
+    if secret not in _fernet_cache:
+        key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode("utf-8")).digest())
+        _fernet_cache[secret] = Fernet(key)
+    return _fernet_cache[secret]
 
 
 def _encrypt(plaintext: str) -> str:

--- a/app/services/byok.py
+++ b/app/services/byok.py
@@ -123,32 +123,23 @@ def add_api_key(
     api_key = payload.api_key.strip()
     if not api_key:
         raise ValueError("API key must not be empty")
-    existing = conn.execute(
-        "SELECT id FROM user_api_keys WHERE provider = ? LIMIT 1",
-        (provider,),
-    ).fetchone()
-    if existing:
-        conn.execute(
-            "DELETE FROM user_api_keys WHERE provider = ?",
-            (provider,),
-        )
     encrypted = _encrypt(api_key)
     label = payload.label.strip() or _PROVIDER_LABELS.get(provider, provider)
-    cursor = conn.execute(
+    conn.execute(
         """
-        INSERT INTO user_api_keys (provider, encrypted_key, label, enabled)
+        INSERT OR REPLACE INTO user_api_keys (provider, encrypted_key, label, enabled)
         VALUES (?, ?, ?, 1)
         """,
         (provider, encrypted, label),
     )
     conn.commit()
-    row_id = cursor.lastrowid
     row = conn.execute(
         """
         SELECT id, provider, encrypted_key, label, enabled, created_at, updated_at
-        FROM user_api_keys WHERE id = ?
+        FROM user_api_keys WHERE provider = ?
+        ORDER BY id DESC LIMIT 1
         """,
-        (row_id,),
+        (provider,),
     ).fetchone()
     plain = _decrypt(str(row["encrypted_key"]))
     return UserApiKeyEntry(

--- a/app/services/byok.py
+++ b/app/services/byok.py
@@ -6,7 +6,7 @@ import logging
 import sqlite3
 from dataclasses import dataclass
 
-from cryptography.fernet import Fernet, InvalidToken
+from cryptography.fernet import Fernet
 
 from app.config import get_settings
 
@@ -93,7 +93,7 @@ def list_api_keys(conn: sqlite3.Connection) -> list[UserApiKeyEntry]:
     for row in rows:
         try:
             plain = _decrypt(str(row["encrypted_key"]))
-        except InvalidToken:
+        except Exception:
             _LOG.warning("failed to decrypt key id=%s", row["id"])
             plain = ""
         entries.append(
@@ -189,7 +189,7 @@ def resolve_api_key(conn: sqlite3.Connection, provider: str) -> str | None:
         return None
     try:
         return _decrypt(str(row["encrypted_key"]))
-    except InvalidToken:
+    except Exception:
         _LOG.warning("failed to decrypt BYOK key for provider %s", provider)
         return None
 
@@ -209,7 +209,7 @@ def resolve_all_api_keys(conn: sqlite3.Connection) -> dict[str, str]:
             continue
         try:
             result[provider] = _decrypt(str(row["encrypted_key"]))
-        except InvalidToken:
+        except Exception:
             _LOG.warning("failed to decrypt BYOK key for provider %s", provider)
     return result
 

--- a/app/services/byok.py
+++ b/app/services/byok.py
@@ -40,6 +40,9 @@ _PROVIDER_ENV_MAP = {
 
 @functools.lru_cache(maxsize=1)
 def _make_fernet(secret: str) -> Fernet:
+    """Cache keyed on *secret* — changing the encryption secret at runtime
+    requires a process restart; previously encrypted data will not be
+    decryptable with a different secret."""
     key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode("utf-8")).digest())
     return Fernet(key)
 
@@ -178,6 +181,18 @@ def toggle_api_key(conn: sqlite3.Connection, key_id: int, *, enabled: bool) -> b
         WHERE id = ?
         """,
         (1 if enabled else 0, key_id),
+    )
+    conn.commit()
+    return cursor.rowcount > 0
+
+
+def flip_api_key_enabled(conn: sqlite3.Connection, key_id: int) -> bool:
+    cursor = conn.execute(
+        """
+        UPDATE user_api_keys SET enabled = 1 - enabled, updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?
+        """,
+        (key_id,),
     )
     conn.commit()
     return cursor.rowcount > 0

--- a/app/templates/byok.html
+++ b/app/templates/byok.html
@@ -77,7 +77,7 @@
                   <button type="submit">{% if key.enabled %}Disable{% else %}Enable{% endif %}</button>
                 </form>
                 <form method="post" action="/byok/{{ key.id }}/delete" style="display:inline"
-                      onsubmit="return confirm('Delete this API key?')">
+                      class="delete-key-form">
                   <button type="submit" class="danger">Delete</button>
                 </form>
               </td>
@@ -92,5 +92,12 @@
       </section>
       {% endif %}
     </main>
+    <script>
+      document.querySelectorAll('.delete-key-form').forEach(function(form) {
+        form.addEventListener('submit', function(e) {
+          if (!confirm('Delete this API key?')) e.preventDefault();
+        });
+      });
+    </script>
   </body>
 </html>

--- a/app/templates/byok.html
+++ b/app/templates/byok.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="/static/app.css">
+  </head>
+  <body>
+    <main class="container">
+      <p>
+        <a href="/">Back to runs</a> ·
+        <a href="/settings">Settings</a>
+      </p>
+
+      <header>
+        <h1>{{ title }}</h1>
+        <p class="muted">Bring your own API keys to use with Software Factory. Keys are encrypted at rest.</p>
+      </header>
+
+      {% if message %}
+      <p class="status {{ message_class | default('ok') }}">{{ message }}</p>
+      {% endif %}
+
+      <section>
+        <h2>Add API Key</h2>
+        <form method="post" action="/byok" class="settings-form">
+          <label for="provider">Provider</label>
+          <select id="provider" name="provider" required>
+            {% for p in providers %}
+            <option value="{{ p.value }}" {% if form.provider | default('') == p.value %}selected{% endif %}>{{ p.label }}</option>
+            {% endfor %}
+          </select>
+
+          <label for="api_key">API Key</label>
+          <input type="password" id="api_key" name="api_key" required placeholder="sk-...">
+
+          <label for="label">Label (optional)</label>
+          <input type="text" id="label" name="label" value="{{ form.label | default('') }}" placeholder="e.g. My Anthropic Key">
+
+          <div class="actions">
+            <button type="submit">Add Key</button>
+          </div>
+        </form>
+      </section>
+
+      {% if keys %}
+      <section>
+        <h2>Stored Keys</h2>
+        <table class="runs-table">
+          <thead>
+            <tr>
+              <th>Provider</th>
+              <th>Label</th>
+              <th>Key</th>
+              <th>Status</th>
+              <th>Added</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for key in keys %}
+            <tr>
+              <td>{{ key.provider }}</td>
+              <td>{{ key.label }}</td>
+              <td><code>{{ key.masked_key }}</code></td>
+              <td>
+                {% if key.enabled %}
+                <span class="status ok">Active</span>
+                {% else %}
+                <span class="status">Disabled</span>
+                {% endif %}
+              </td>
+              <td class="tiny">{{ key.created_at }}</td>
+              <td>
+                <form method="post" action="/byok/{{ key.id }}/toggle" style="display:inline">
+                  <button type="submit">{% if key.enabled %}Disable{% else %}Enable{% endif %}</button>
+                </form>
+                <form method="post" action="/byok/{{ key.id }}/delete" style="display:inline"
+                      onsubmit="return confirm('Delete this API key?')">
+                  <button type="submit" class="danger">Delete</button>
+                </form>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </section>
+      {% else %}
+      <section>
+        <p class="muted">No API keys stored yet. Add one above to get started.</p>
+      </section>
+      {% endif %}
+    </main>
+  </body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -17,6 +17,7 @@
         <nav class="header-nav">
           <a href="/issues">Submit issue</a>
           <a href="/settings">Settings</a>
+          <a href="/byok">API Keys</a>
         </nav>
       </header>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic-settings>=2.3,<3.0
 python-dotenv>=1.0,<2.0
 httpx>=0.27,<1.0
 python-multipart>=0.0.9,<1.0
+cryptography>=43.0,<44.0

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -2762,6 +2762,7 @@ def test_execute_agent_sdks_falls_back_to_claude(
         timeout_seconds: int,
         on_log_line: object | None = None,
         should_cancel: object | None = None,
+        byok_overrides: object | None = None,
     ) -> tuple[bool, str, str | None]:
         calls.append(workspace)
         return True, "claude succeeded", None
@@ -2818,6 +2819,7 @@ def test_execute_agent_sdks_falls_back_to_openhands_after_claude_failure(
         timeout_seconds: int,
         on_log_line: object | None = None,
         should_cancel: object | None = None,
+        byok_overrides: object | None = None,
     ) -> tuple[bool, str, str | None]:
         calls.append("claude")
         return False, "claude failed", "agent_claude_failed"

--- a/tests/test_byok.py
+++ b/tests/test_byok.py
@@ -38,11 +38,16 @@ def db_conn(tmp_path, monkeypatch):
 
 
 class TestEncryptDecrypt:
-    def test_roundtrip(self):
+    def test_roundtrip(self, monkeypatch):
+        from app.config import get_settings
+
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret-for-byok")
+        get_settings.cache_clear()
         original = "sk-test-key-12345"
         encrypted = _encrypt(original)
         assert encrypted != original
         assert _decrypt(encrypted) == original
+        get_settings.cache_clear()
 
     def test_different_keys_produce_different_ciphertext(self, monkeypatch):
         from app.config import get_settings
@@ -59,13 +64,18 @@ class TestEncryptDecrypt:
         assert encrypted_a != encrypted_b
         get_settings.cache_clear()
 
-    def test_same_plaintext_different_ciphertexts(self):
+    def test_same_plaintext_different_ciphertexts(self, monkeypatch):
+        from app.config import get_settings
+
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret-for-byok")
+        get_settings.cache_clear()
         original = "sk-same-key"
         encrypted_a = _encrypt(original)
         encrypted_b = _encrypt(original)
         assert encrypted_a != encrypted_b
         assert _decrypt(encrypted_a) == original
         assert _decrypt(encrypted_b) == original
+        get_settings.cache_clear()
 
     def test_missing_encryption_key_raises(self, monkeypatch):
         from app.config import get_settings

--- a/tests/test_byok.py
+++ b/tests/test_byok.py
@@ -15,6 +15,7 @@ from app.services.byok import (
     add_api_key,
     build_byok_env_overrides,
     delete_api_key,
+    flip_api_key_enabled,
     list_api_keys,
     resolve_api_key,
     resolve_all_api_keys,
@@ -244,6 +245,31 @@ class TestResolveAllApiKeys:
         all_keys = resolve_all_api_keys(db_conn)
         assert "anthropic" not in all_keys
         assert all_keys["openai"] == "active-key"
+
+
+class TestFlipApiKeyEnabled:
+    def test_flip_disables_enabled_key(self, db_conn):
+        entry = add_api_key(
+            db_conn, UserApiKeyCreatePayload("anthropic", "sk-test-flip", "")
+        )
+        assert entry.enabled is True
+        result = flip_api_key_enabled(db_conn, entry.id)
+        assert result is True
+        keys = list_api_keys(db_conn)
+        assert keys[0].enabled is False
+
+    def test_double_flip_restores_state(self, db_conn):
+        entry = add_api_key(
+            db_conn, UserApiKeyCreatePayload("openai", "sk-test-double", "")
+        )
+        flip_api_key_enabled(db_conn, entry.id)
+        flip_api_key_enabled(db_conn, entry.id)
+        keys = list_api_keys(db_conn)
+        assert keys[0].enabled is True
+
+    def test_flip_nonexistent_returns_false(self, db_conn):
+        result = flip_api_key_enabled(db_conn, 99999)
+        assert result is False
 
 
 class TestBuildByokEnvOverrides:

--- a/tests/test_byok.py
+++ b/tests/test_byok.py
@@ -59,6 +59,38 @@ class TestEncryptDecrypt:
         assert encrypted_a != encrypted_b
         get_settings.cache_clear()
 
+    def test_same_plaintext_different_ciphertexts(self):
+        original = "sk-same-key"
+        encrypted_a = _encrypt(original)
+        encrypted_b = _encrypt(original)
+        assert encrypted_a != encrypted_b
+        assert _decrypt(encrypted_a) == original
+        assert _decrypt(encrypted_b) == original
+
+    def test_missing_encryption_key_raises(self, monkeypatch):
+        from app.config import get_settings
+
+        monkeypatch.delenv("GITHUB_WEBHOOK_SECRET", raising=False)
+        get_settings.cache_clear()
+        with pytest.raises(RuntimeError, match="GITHUB_WEBHOOK_SECRET"):
+            _encrypt("test")
+        get_settings.cache_clear()
+
+    def test_wrong_key_decrypt_fails(self, monkeypatch):
+        from cryptography.fernet import InvalidToken
+
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "secret-a")
+        from app.config import get_settings
+
+        get_settings.cache_clear()
+        encrypted = _encrypt("test-key")
+
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "secret-b")
+        get_settings.cache_clear()
+        with pytest.raises(InvalidToken):
+            _decrypt(encrypted)
+        get_settings.cache_clear()
+
 
 class TestMaskKey:
     def test_short_key(self):

--- a/tests/test_byok.py
+++ b/tests/test_byok.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import pytest
+
+from app.db import connect_db, init_db
+from app.services.byok import (
+    SUPPORTED_PROVIDERS,
+    UserApiKeyCreatePayload,
+    _decrypt,
+    _encrypt,
+    _mask_key,
+    add_api_key,
+    build_byok_env_overrides,
+    delete_api_key,
+    list_api_keys,
+    resolve_api_key,
+    resolve_all_api_keys,
+    toggle_api_key,
+)
+
+
+@pytest.fixture
+def db_conn(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "test.db")
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-secret-for-byok")
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+    init_db()
+    conn = connect_db()
+    yield conn
+    conn.close()
+    get_settings.cache_clear()
+
+
+class TestEncryptDecrypt:
+    def test_roundtrip(self):
+        original = "sk-test-key-12345"
+        encrypted = _encrypt(original)
+        assert encrypted != original
+        assert _decrypt(encrypted) == original
+
+    def test_different_keys_produce_different_ciphertext(self, monkeypatch):
+        from app.config import get_settings
+
+        get_settings.cache_clear()
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "secret-a")
+        get_settings.cache_clear()
+        encrypted_a = _encrypt("test-key")
+
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "secret-b")
+        get_settings.cache_clear()
+        encrypted_b = _encrypt("test-key")
+
+        assert encrypted_a != encrypted_b
+        get_settings.cache_clear()
+
+
+class TestMaskKey:
+    def test_short_key(self):
+        assert _mask_key("short") == "****"
+
+    def test_long_key(self):
+        assert _mask_key("sk-1234567890abcdef") == "sk-1****cdef"
+
+    def test_exactly_8_chars(self):
+        assert _mask_key("12345678") == "****"
+
+
+class TestAddApiKey:
+    def test_add_key_success(self, db_conn):
+        payload = UserApiKeyCreatePayload(
+            provider="anthropic", api_key="sk-ant-test123456", label="Test Key"
+        )
+        entry = add_api_key(db_conn, payload)
+        assert entry.id > 0
+        assert entry.provider == "anthropic"
+        assert entry.label == "Test Key"
+        assert "****" in entry.masked_key
+        assert entry.enabled is True
+
+    def test_add_key_unsupported_provider(self, db_conn):
+        payload = UserApiKeyCreatePayload(
+            provider="invalid_provider", api_key="test-key", label=""
+        )
+        with pytest.raises(ValueError, match="unsupported provider"):
+            add_api_key(db_conn, payload)
+
+    def test_add_key_empty_api_key(self, db_conn):
+        payload = UserApiKeyCreatePayload(
+            provider="anthropic", api_key="  ", label=""
+        )
+        with pytest.raises(ValueError, match="must not be empty"):
+            add_api_key(db_conn, payload)
+
+    def test_add_key_default_label(self, db_conn):
+        payload = UserApiKeyCreatePayload(
+            provider="openai", api_key="sk-test-key", label=""
+        )
+        entry = add_api_key(db_conn, payload)
+        assert entry.label == "OpenAI"
+
+    def test_add_key_all_providers(self, db_conn):
+        for provider in SUPPORTED_PROVIDERS:
+            payload = UserApiKeyCreatePayload(
+                provider=provider, api_key=f"key-for-{provider}", label=""
+            )
+            entry = add_api_key(db_conn, payload)
+            assert entry.provider == provider
+
+
+class TestListApiKeys:
+    def test_empty_list(self, db_conn):
+        keys = list_api_keys(db_conn)
+        assert keys == []
+
+    def test_list_multiple_keys(self, db_conn):
+        add_api_key(db_conn, UserApiKeyCreatePayload("anthropic", "key1", "A"))
+        add_api_key(db_conn, UserApiKeyCreatePayload("openai", "key2", "B"))
+        keys = list_api_keys(db_conn)
+        assert len(keys) == 2
+        providers = {k.provider for k in keys}
+        assert providers == {"anthropic", "openai"}
+
+
+class TestDeleteApiKey:
+    def test_delete_existing(self, db_conn):
+        entry = add_api_key(
+            db_conn, UserApiKeyCreatePayload("anthropic", "key-to-delete", "")
+        )
+        assert delete_api_key(db_conn, entry.id) is True
+        assert list_api_keys(db_conn) == []
+
+    def test_delete_nonexistent(self, db_conn):
+        assert delete_api_key(db_conn, 99999) is False
+
+
+class TestToggleApiKey:
+    def test_disable_key(self, db_conn):
+        entry = add_api_key(
+            db_conn, UserApiKeyCreatePayload("anthropic", "key-to-disable", "")
+        )
+        assert toggle_api_key(db_conn, entry.id, enabled=False) is True
+        keys = list_api_keys(db_conn)
+        assert keys[0].enabled is False
+
+    def test_re_enable_key(self, db_conn):
+        entry = add_api_key(
+            db_conn, UserApiKeyCreatePayload("anthropic", "key-to-toggle", "")
+        )
+        toggle_api_key(db_conn, entry.id, enabled=False)
+        toggle_api_key(db_conn, entry.id, enabled=True)
+        keys = list_api_keys(db_conn)
+        assert keys[0].enabled is True
+
+    def test_toggle_nonexistent(self, db_conn):
+        assert toggle_api_key(db_conn, 99999, enabled=False) is False
+
+
+class TestResolveApiKey:
+    def test_resolve_existing_key(self, db_conn):
+        add_api_key(
+            db_conn, UserApiKeyCreatePayload("zhipu", "my-zhipu-key", "")
+        )
+        resolved = resolve_api_key(db_conn, "zhipu")
+        assert resolved == "my-zhipu-key"
+
+    def test_resolve_missing_key(self, db_conn):
+        assert resolve_api_key(db_conn, "anthropic") is None
+
+    def test_resolve_disabled_key(self, db_conn):
+        entry = add_api_key(
+            db_conn, UserApiKeyCreatePayload("deepseek", "disabled-key", "")
+        )
+        toggle_api_key(db_conn, entry.id, enabled=False)
+        assert resolve_api_key(db_conn, "deepseek") is None
+
+    def test_resolve_prefers_latest(self, db_conn):
+        add_api_key(db_conn, UserApiKeyCreatePayload("openai", "old-key", "Old"))
+        add_api_key(db_conn, UserApiKeyCreatePayload("openai", "new-key", "New"))
+        assert resolve_api_key(db_conn, "openai") == "new-key"
+
+
+class TestResolveAllApiKeys:
+    def test_resolve_multiple_providers(self, db_conn):
+        add_api_key(db_conn, UserApiKeyCreatePayload("anthropic", "ant-key", ""))
+        add_api_key(db_conn, UserApiKeyCreatePayload("openai", "oai-key", ""))
+        all_keys = resolve_all_api_keys(db_conn)
+        assert all_keys["anthropic"] == "ant-key"
+        assert all_keys["openai"] == "oai-key"
+
+    def test_resolve_skips_disabled(self, db_conn):
+        entry = add_api_key(
+            db_conn, UserApiKeyCreatePayload("anthropic", "disabled-key", "")
+        )
+        toggle_api_key(db_conn, entry.id, enabled=False)
+        add_api_key(db_conn, UserApiKeyCreatePayload("openai", "active-key", ""))
+        all_keys = resolve_all_api_keys(db_conn)
+        assert "anthropic" not in all_keys
+        assert all_keys["openai"] == "active-key"
+
+
+class TestBuildByokEnvOverrides:
+    def test_builds_env_map(self, db_conn):
+        add_api_key(
+            db_conn, UserApiKeyCreatePayload("anthropic", "sk-ant-test", "")
+        )
+        add_api_key(
+            db_conn, UserApiKeyCreatePayload("openai", "sk-oai-test", "")
+        )
+        add_api_key(
+            db_conn, UserApiKeyCreatePayload("zhipu", "zhipu-test-key", "")
+        )
+        overrides = build_byok_env_overrides(db_conn)
+        assert overrides["ANTHROPIC_API_KEY"] == "sk-ant-test"
+        assert overrides["OPENAI_API_KEY"] == "sk-oai-test"
+        assert overrides["ZHIPU_API_KEY"] == "zhipu-test-key"
+
+    def test_empty_overrides(self, db_conn):
+        overrides = build_byok_env_overrides(db_conn)
+        assert overrides == {}


### PR DESCRIPTION
## Problem

Software Factory 部署线上实例时，用户无法使用自己的 LLM API key，只能依赖服务端预配置的 key。这阻碍了公开实例的体验试用（#207）。

## Approach

实现 BYOK（Bring Your Own Key）功能，让用户通过 Web UI 或 REST API 管理自己的 API key，并在 agent 运行时自动注入：

- **数据层**：新增 `user_api_keys` 表，使用 `cryptography.Fernet`（密钥派生自 `GITHUB_WEBHOOK_SECRET` 的 SHA-256）对 API key 进行加密存储。通过 `db.py` 迁移自动建表。
- **服务层**（`app/services/byok.py`）：提供 `add_api_key`、`list_api_keys`、`delete_api_key`、`toggle_api_key`、`resolve_api_key`、`build_byok_env_overrides` 等完整 CRUD + 解密解析接口。支持 5 个 provider：Anthropic、OpenAI、ZhipuAI、DeepSeek、OpenRouter。
- **路由层**（`app/routes/byok.py`）：提供 Web 页面（`/byok`）和 REST API（`/api/byok/keys`）。API 端点受 `byok_admin_token` 配置保护（可选 Bearer token 鉴权）。
- **集成 agent_runner**：在 `run_once` 中调用 `build_byok_env_overrides` 获取用户 key，传递到 `_build_claude_agent_environment`，BYOK key 优先于环境变量中的 key。`ai_client.py` 的 `generate_fix` 同理使用 BYOK override。
- **前端**：`byok.html` 模板提供 key 管理 UI（添加/启用/禁用/删除），首页导航栏增加 "API Keys" 入口。

## Tests

新增 `tests/test_byok.py`（257 行），覆盖：

- 加密/解密 roundtrip、不同密钥产生不同密文、密钥缺失报错、错误密钥解密失败
- `_mask_key` 短 key 和长 key 的遮盖逻辑
- `add_api_key` 成功添加、不支持的 provider、空 key、默认 label、全部 5 个 provider
- `list_api_keys` 空列表和多条记录
- `delete_api_key` 删除存在/不存在记录
- `toggle_api_key` 禁用/重新启用/不存在记录
- `resolve_api_key` 解析已存储/缺失/已禁用 key，以及同 provider 多 key 时取最新
- `resolve_all_api_keys` 多 provider 和跳过禁用 key
- `build_byok_env_overrides` 构建正确的环境变量映射

`tests/test_agent_runner.py` 中两处 mock 签名已同步更新 `byok_overrides` 参数。

Closes #207