### PR TITLE
fix(hooks): log warnings when _read_metadata fails JSON parse or gets non-dict

### DIFF
--- a/app/services/hooks.py
+++ b/app/services/hooks.py
@@ -429,10 +429,13 @@ def _read_metadata(raw_value: str | None) -> dict[str, Any]:
         return {}
     try:
         loaded = json.loads(raw_value)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        preview = raw_value[:200] if len(raw_value) > 200 else raw_value
+        logger.warning("Failed to parse metadata JSON: %s (raw preview: %r)", exc, preview)
         return {}
     if isinstance(loaded, dict):
         return loaded
+    logger.warning("Metadata is not a dict, got: %s", type(loaded).__name__)
     return {}
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+
+from app.services.hooks import _read_metadata
+
+
+def test_read_metadata_valid_dict() -> None:
+    result = _read_metadata('{"key": "val"}')
+    assert result == {"key": "val"}
+
+
+def test_read_metadata_none_or_empty() -> None:
+    assert _read_metadata(None) == {}
+    assert _read_metadata("") == {}
+
+
+def test_read_metadata_corrupted_json_warns(caplog) -> None:  # type: ignore[no-untyped-def]
+    with caplog.at_level(logging.WARNING, logger="app.services.hooks"):
+        result = _read_metadata("{broken")
+    assert result == {}
+    assert any("Failed to parse metadata JSON" in m for m in caplog.messages)
+
+
+def test_read_metadata_non_dict_warns(caplog) -> None:  # type: ignore[no-untyped-def]
+    with caplog.at_level(logging.WARNING, logger="app.services.hooks"):
+        result = _read_metadata("[1, 2, 3]")
+    assert result == {}
+    assert any("Metadata is not a dict" in m for m in caplog.messages)
+
+
+def test_read_metadata_valid_does_not_warn(caplog) -> None:  # type: ignore[no-untyped-def]
+    with caplog.at_level(logging.WARNING, logger="app.services.hooks"):
+        _read_metadata('{"key": "val"}')
+    assert len(caplog.messages) == 0


### PR DESCRIPTION
## Repro
`_read_metadata('{broken')` returns `{}` with exit code 0 and zero log output. Same for `_read_metadata('[1,2,3]')`. When metadata is corrupted in the database, callers at `_register_session` (L107), `_record_tool_event` (L168), and `_link_pr_for_session` (L224) silently re-serialize an empty dict, permanently losing whatever metadata survived the corruption.

## Cause
`_read_metadata` in `app/services/hooks.py:427-436` had bare `except json.JSONDecodeError: return {}` and a silent `return {}` on non-dict values — no diagnostic signal emitted.

## Fix
- Added `logger.warning` in the `json.JSONDecodeError` handler, including the exception text and a truncated (200-char) preview of the raw value for diagnostics.
- Added `logger.warning` when the loaded value is not a dict, naming the actual type.
- New unit tests covering valid dict, None/empty, corrupted JSON warning, non-dict warning, and valid-dict-does-not-warn paths.

## Verification
Ran all five new tests manually (pytest unavailable in env):
```
PASS test_read_metadata_valid_dict
PASS test_read_metadata_none_or_empty
PASS test_read_metadata_corrupted_json_warns
PASS test_read_metadata_non_dict_warns
PASS test_read_metadata_valid_does_not_warn
```
Fixes #214