### PR TITLE
fix(retry): preserve terminal status in schedule_retry

### DIFF
--- a/app/services/retry.py
+++ b/app/services/retry.py
@@ -117,14 +117,24 @@ def schedule_retry(
     current_time = _normalize_now(now)
     error_time = _to_timestamp(current_time)
 
-    if not should_retry(
+    can_retry = should_retry(
         status=status,
         attempt_count=attempt_count,
         max_attempts=max_attempts,
         retryable=retryable,
         error_code=error_code,
         non_retryable_error_codes=config.non_retryable_error_codes,
-    ):
+    )
+
+    if not can_retry:
+        if status in TERMINAL_STATUSES:
+            return RetryPlan(
+                run_id=run_id,
+                scheduled=False,
+                retry_after=None,
+                delay_seconds=None,
+                next_attempt_count=attempt_count,
+            )
         conn.execute(
             """
             UPDATE autofix_runs

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -205,3 +205,41 @@ def test_schedule_retry_backward_compat_individual_params() -> None:
     assert plan.retry_after == "2026-03-12T10:00:20Z"
     assert row is not None
     assert row["status"] == "retry_scheduled"
+
+
+def test_schedule_retry_preserves_terminal_status() -> None:
+    """schedule_retry must not mutate terminal runs (success, cancelled)."""
+    for terminal_status in ("success", "cancelled"):
+        conn = _make_conn()
+        cursor = conn.execute(
+            """
+            INSERT INTO autofix_runs (repo, pr_number, status, attempt_count, max_attempts, retryable)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("acme/widgets", 99, terminal_status, 1, 3, 1),
+        )
+        conn.commit()
+        run_id = cursor.lastrowid
+        assert run_id is not None
+
+        plan = schedule_retry(
+            conn,
+            run_id,
+            error_code="late_error",
+            config=RetryConfig(),
+        )
+
+        row = conn.execute(
+            "SELECT status, last_error_code, last_error_at FROM autofix_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+
+        assert plan.scheduled is False, f"should not schedule retry for {terminal_status}"
+        assert row is not None
+        assert row["status"] == terminal_status, (
+            f"status must remain {terminal_status}, got {row['status']}"
+        )
+        assert row["last_error_code"] is None, "terminal runs should not be mutated"
+        assert row["last_error_at"] is None, "terminal runs should not be mutated"
+
+        conn.close()


### PR DESCRIPTION
## Repro
```python
conn = sqlite3.connect(':memory:')
# ... create a run with status='success'
schedule_retry(conn, run_id, error_code='late_error', config=RetryConfig())
# status changed from 'success' to 'failed' ❌
```

## Cause
`app/services/retry.py:schedule_retry` — when `should_retry()` returns `False` (which it correctly does for terminal statuses `success`/`cancelled`), the function unconditionally executes `UPDATE ... SET status = 'failed'`, destroying the terminal status.

## Fix
Add a guard in `schedule_retry`: after `should_retry()` returns `False`, check if `status` is in `TERMINAL_STATUSES`. If so, return a `RetryPlan(scheduled=False, ...)` without any database mutation.

## Verification
```
$ python -c "... run all retry tests ..."
PASS should_retry_respects_limits
PASS compute_backoff
PASS schedule_retry_updates_fields
PASS schedule_retry_non_retryable
PASS schedule_retry_backoff
PASS schedule_retry_backward_compat
PASS schedule_retry_preserves_terminal_status
7 passed, 0 failed
```

New test `test_schedule_retry_preserves_terminal_status` covers both `success` and `cancelled` terminal states.

Fixes #217