### PR TITLE
fix(queue): skip spurious UPDATE when run already cancel_requested

### DIFF
--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -366,8 +366,7 @@ def request_run_cancel(conn: sqlite3.Connection, run_id: int) -> str | None:
     current_status = get_run_status(conn, run_id)
     if current_status is None:
         return None
-
-    if current_status in {"success", "failed", "cancelled"}:
+    if current_status in {"success", "failed", "cancelled", "cancel_requested"}:
         return current_status
 
     if current_status in {"queued", "retry_scheduled"}:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -10,8 +10,10 @@ from app.services.queue import (
     claim_next_queued_run,
     enqueue_autofix_run,
     get_run_operator_hints,
+    get_run_status,
     mark_run_finished,
     recover_stale_runs,
+    request_run_cancel,
     touch_run_progress,
 )
 
@@ -196,3 +198,41 @@ def test_append_run_operator_hint_rejects_oversized_append() -> None:
 
     with pytest.raises(ValueError, match="operator hint exceeds max length"):
         append_run_operator_hint(conn, run_id, "x" * 1001)
+
+
+def test_request_run_cancel_idempotent_on_cancel_requested() -> None:
+    """Double-cancel on cancel_requested must not execute a spurious UPDATE."""
+    conn = _make_conn()
+    run_id = enqueue_autofix_run(
+        conn=conn,
+        repo="acme/w",
+        pr_number=1,
+        head_sha="abc",
+        normalized_review_json={},
+    )
+    assert run_id is not None
+
+    # Transition to running, then first cancel → cancel_requested
+    claimed = claim_next_queued_run(conn)
+    assert claimed is not None and claimed["status"] == "running"
+
+    result = request_run_cancel(conn, run_id)
+    assert result == "cancel_requested"
+    assert get_run_status(conn, run_id) == "cancel_requested"
+
+    updated_at_before = conn.execute(
+        "SELECT updated_at FROM autofix_runs WHERE id = ?", (run_id,)
+    ).fetchone()["updated_at"]
+
+    # Second cancel on same run — must be no-op (no UPDATE)
+    result = request_run_cancel(conn, run_id)
+    assert result == "cancel_requested"
+
+    row = conn.execute(
+        "SELECT status, updated_at, error_summary FROM autofix_runs WHERE id = ?",
+        (run_id,),
+    ).fetchone()
+    assert row["status"] == "cancel_requested"
+    assert row["updated_at"] == updated_at_before
+    # error_summary must still be the original cancel value, not overwritten
+    assert row["error_summary"] == "cancel_requested_by_user"


### PR DESCRIPTION
## Repro
Call `request_run_cancel` on a run already in `cancel_requested` status. The function executes an unnecessary `UPDATE` rewriting the same status and updating `updated_at`, even though no state change occurs.

```python
# After first cancel transitions running → cancel_requested:
request_run_cancel(conn, run_id)  # BUG: executes UPDATE, bumps updated_at
```

## Cause
`request_run_cancel` in `app/services/queue.py:365` guards terminal states (`success`, `failed`, `cancelled`) and queued/retry states, but `cancel_requested` falls through to the final `UPDATE` block (lines 390-403), executing a write every time.

## Fix
- Add `cancel_requested` to the terminal-state guard on line 370, returning early without touching the database.
- Add unit test `test_request_run_cancel_idempotent_on_cancel_requested` asserting `updated_at` is stable across duplicate cancel calls, and `error_summary` is not overwritten.

## Verification
Standalone verification passes — double-cancel no longer updates `updated_at`, all status transitions still work correctly. `Fixes #219`