### PR TITLE
fix(agent): check all argv tokens for shell control operators, not argv[1:]

### DIFF
--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -1880,7 +1880,7 @@ def _run_claude_container_command(
         return False, f"{agent_name} command is invalid: {exc}", failure_code
     if not inner_argv:
         return False, f"{agent_name} command is not configured", failure_code
-    if any(token in _DISALLOWED_COMMAND_TOKENS for token in inner_argv[1:]):
+    if any(token in _DISALLOWED_COMMAND_TOKENS for token in inner_argv):
         return (
             False,
             f"{agent_name} command contains unsupported shell control operators",
@@ -1954,7 +1954,7 @@ def _run_claude_stream_command(
         return False, f"{agent_name} command is invalid: {exc}", failure_code
     if not argv:
         return False, f"{agent_name} command is not configured", failure_code
-    if any(token in _DISALLOWED_COMMAND_TOKENS for token in argv[1:]):
+    if any(token in _DISALLOWED_COMMAND_TOKENS for token in argv):
         return (
             False,
             f"{agent_name} command contains unsupported shell control operators",
@@ -2331,7 +2331,7 @@ def _run_agent_command(
         return False, f"{agent_name} command is invalid: {exc}", failure_code
     if not argv:
         return False, f"{agent_name} command is not configured", failure_code
-    if any(token in _DISALLOWED_COMMAND_TOKENS for token in argv[1:]):
+    if any(token in _DISALLOWED_COMMAND_TOKENS for token in argv):
         return (
             False,
             f"{agent_name} command contains unsupported shell control operators",

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -3453,6 +3453,53 @@ def test_run_claude_agent_rejects_shell_control_tokens(tmp_path: Path) -> None:
     assert "unsupported shell control operators" in message
 
 
+def test_run_claude_agent_rejects_shell_control_token_as_argv0(tmp_path: Path) -> None:
+    """Shell metacharacter as argv[0] must be caught (not skipped)."""
+    ok, message, error_code = _run_claude_agent(
+        workspace=str(tmp_path),
+        run_id=10,
+        repo="acme/widgets",
+        pr_number=8,
+        prompt="fix this",
+        normalized_review={},
+        command="&& true",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api",
+        model="openrouter/hunter-alpha",
+        runtime="host",
+        container_image="",
+        timeout_seconds=42,
+    )
+
+    assert ok is False
+    assert error_code == "agent_claude_failed"
+    assert "unsupported shell control operators" in message
+
+
+def test_run_ralph_agent_rejects_shell_control_token_as_argv0(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Shell metacharacter as argv[0] caught in _run_agent_command path."""
+    monkeypatch.setenv("PATH", os.environ.get("PATH", ""))
+    monkeypatch.setattr(agent_runner.shutil, "which", lambda value: f"/usr/bin/{value}")
+
+    ok, message, error_code = agent_runner._run_ralph_agent(
+        workspace=str(tmp_path),
+        run_id=10,
+        repo="acme/widgets",
+        pr_number=8,
+        prompt="fix this",
+        normalized_review={},
+        command="&& true",
+        timeout_seconds=42,
+    )
+
+    assert ok is False
+    assert error_code == "agent_ralph_failed"
+    assert "unsupported shell control operators" in message
+
+
 def test_sanitize_log_text_redacts_tokens() -> None:
     raw = (
         "token=abc123 secret: xyz ghp_abcdefghijklmnopqrstuvwxyz "


### PR DESCRIPTION
## Repro

```
python3 -c "
import shlex
_DISALLOWED_COMMAND_TOKENS = {'&&', ';', '|', ...}
argv = shlex.split('&& true')
print(any(token in _DISALLOWED_COMMAND_TOKENS for token in argv[1:]))  # False — missed!
"
```

The shell metacharacter check in `agent_runner.py` used `argv[1:]`, skipping the
first token. `&& true` passes unchecked because `&&` lands in `argv[0]`.

## Cause

Three functions in `app/services/agent_runner.py` each have the check:

- `_run_claude_container_command` (line 1883): `inner_argv[1:]`
- `_run_claude_stream_command` (line 1957): `argv[1:]`
- `_run_agent_command` (line 2334): `argv[1:]`

All three skip `argv[0]`. While `subprocess.Popen` is called without
`shell=True`, the check is intended as a defense-in-depth guard — any
future refactor that adds `shell=True` would expose this gap.

## Fix

- Changed `inner_argv[1:]` / `argv[1:]` to the full list in all three sites.
- Added `test_run_claude_agent_rejects_shell_control_token_as_argv0` covering
  `&& true` on the Claude agent path.
- Added `test_run_ralph_agent_rejects_shell_control_token_as_argv0` covering
  the same on the `_run_agent_command` path (used by Ralph and OpenHands agents).

## Verification

```
python3 -c "
import shlex
_DISALLOWED_COMMAND_TOKENS = {'&', '&&', ';', '<', '<<', '>', '>>', '|', '||'}
for cmd, expected in [('&& true', True), ('; evil', True), ('echo hello', False)]:
    argv = shlex.split(cmd)
    assert any(t in _DISALLOWED_COMMAND_TOKENS for t in argv) == expected
print('OK')
"
# OK
```

Fixes #215