### PR TITLE
fix(queue): validate status in mark_run_finished

### DIFF
--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -3659,7 +3659,7 @@ def _should_post_run_comment(
     payload: Mapping[str, Any],
     status: str,
 ) -> bool:
-    if status == "retry_scheduled":
+    if status in {"retry_scheduled", "waiting_for_baseline_fix"}:
         return False
     if _safe_text(run.get("trigger_source")) in {"manual_issue", "manual_task"}:
         return False

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -147,6 +147,8 @@ def claim_next_queued_run(
         return {key: value for key, value in zip(keys, row, strict=False)}
     return _to_dict(row, conn.cursor())
 
+_VALID_FINISH_STATUSES: frozenset[str] = frozenset({"success", "failed", "cancelled"})
+
 
 def mark_run_finished(
     conn: sqlite3.Connection,
@@ -159,6 +161,11 @@ def mark_run_finished(
     opened_pr_number: int | None = None,
     opened_pr_url: str | None = None,
 ) -> None:
+    if status not in _VALID_FINISH_STATUSES:
+        raise ValueError(
+            f"Invalid finish status {status!r}; "
+            f"must be one of {sorted(_VALID_FINISH_STATUSES)}"
+        )
     conn.execute(
         """
         UPDATE autofix_runs

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -196,3 +196,48 @@ def test_append_run_operator_hint_rejects_oversized_append() -> None:
 
     with pytest.raises(ValueError, match="operator hint exceeds max length"):
         append_run_operator_hint(conn, run_id, "x" * 1001)
+
+
+class TestMarkRunFinishedStatusValidation:
+    """Tests for status parameter validation in mark_run_finished."""
+
+    def test_rejects_invalid_status(self) -> None:
+        conn = _make_conn()
+        run_id = enqueue_autofix_run(
+            conn=conn,
+            repo="acme/widgets",
+            pr_number=42,
+            head_sha="abc123",
+            normalized_review_json={"summary": "issue"},
+        )
+        with pytest.raises(ValueError, match="Invalid finish status"):
+            mark_run_finished(conn=conn, run_id=run_id, status="banana")
+
+    def test_rejects_empty_status(self) -> None:
+        conn = _make_conn()
+        run_id = enqueue_autofix_run(
+            conn=conn,
+            repo="acme/widgets",
+            pr_number=42,
+            head_sha="abc123",
+            normalized_review_json={"summary": "issue"},
+        )
+        with pytest.raises(ValueError, match="Invalid finish status"):
+            mark_run_finished(conn=conn, run_id=run_id, status="")
+
+    @pytest.mark.parametrize("valid_status", ["success", "failed", "cancelled"])
+    def test_accepts_valid_finish_statuses(self, valid_status: str) -> None:
+        conn = _make_conn()
+        run_id = enqueue_autofix_run(
+            conn=conn,
+            repo="acme/widgets",
+            pr_number=42,
+            head_sha="abc123",
+            normalized_review_json={"summary": "issue"},
+        )
+        mark_run_finished(conn=conn, run_id=run_id, status=valid_status)
+        row = conn.execute(
+            "SELECT status FROM autofix_runs WHERE id = ?", (run_id,)
+        ).fetchone()
+        assert row is not None
+        assert row["status"] == valid_status


### PR DESCRIPTION
## Repro
`mark_run_finished(conn, run_id, status="banana")` writes `"banana"` to the database without error. Invalid status strings like `""`, `"SUCCESS"`, `"sucess"` are similarly accepted.

## Cause
`mark_run_finished` in `app/services/queue.py` performs no validation on the `status` parameter before writing it into the `autofix_runs` table via a parameterized `UPDATE`. The table schema has no CHECK constraint on the `status` column.

## Fix
- Add `_VALID_FINISH_STATUSES` frozen set (`{"success", "failed", "cancelled"}`) to `app/services/queue.py`.
- Validate `status` at the top of `mark_run_finished`, raising `ValueError` for invalid values.
- Add `"waiting_for_baseline_fix"` to the early-return guard in `app/services/agent_runner.py:_should_post_run_comment` — this prevents a latent path where `_post_run_comment_if_supported` would call `mark_run_finished` with a non-terminal status when posting a PR comment fails for baseline-fix-waiting runs.
- Add `TestMarkRunFinishedStatusValidation` to `tests/test_queue.py` covering valid statuses (`success`, `failed`, `cancelled` via parametrize), invalid statuses (`"banana"`, `""`), and the existing flow test.

## Verification
- `python3 -c "…"` ad-hoc validation suite: 7/7 passed (valid success/failed/cancelled accepted; banana/empty/SUCCESS rejected; existing flow intact).
- `tests/test_queue.py::test_enqueue_claim_finish_status_flow` and new validation tests all pass.

Fixes #218