### PR TITLE
fix(web): hide pagination when total_count is 0

### DIFF
--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -182,7 +182,7 @@ def _fetch_runs(
         ).fetchall()
 
     total_count = int(count_row["total_count"]) if count_row is not None else 0
-    total_pages = max(1, (total_count + page_size - 1) // page_size)
+    total_pages = (total_count + page_size - 1) // page_size if total_count > 0 else 0
     normalized_page = min(page, total_pages)
     runs = [
         {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -48,6 +48,7 @@
           </div>
         </form>
 
+        {% if run_page.total_count > 0 %}
         <p class="muted run-results-summary">
           Showing {{ runs|length }} of {{ run_page.total_count }} runs
           {% if run_page.query %}
@@ -55,6 +56,7 @@
           {% endif %}
           · Page {{ run_page.page }} / {{ run_page.total_pages }}
         </p>
+        {% endif %}
 
         {% if runs and runs|length > 0 %}
         <ul class="run-list">

--- a/tests/test_web_runs.py
+++ b/tests/test_web_runs.py
@@ -110,6 +110,17 @@ def test_fetch_runs_search_with_like_wildcards(tmp_path: Path) -> None:
     assert "acme/testX1" in plain.text
 
 
+def test_fetch_runs_total_pages_zero_when_empty(tmp_path: Path) -> None:
+    db_path = _setup_db(tmp_path)
+    # no rows inserted — DB is empty
+    result = web_routes._fetch_runs(page=1, page_size=10, query="")
+    assert result["total_count"] == 0
+    assert result["total_pages"] == 0
+    assert result["page"] == 0
+    assert result["has_prev"] is False
+    assert result["has_next"] is False
+    assert result["items"] == []
+
 def test_manual_issue_run_detail_omits_fake_pull_request_link(tmp_path: Path) -> None:
     db_path = _setup_db(tmp_path)
     with sqlite3.connect(db_path) as conn:


### PR DESCRIPTION
## Repro
Start the web service with an empty database, navigate to `/`. The runs page displays "Showing 0 of 0 runs · Page 1 / 1" — misleadingly suggesting a page of results when none exist.

## Cause
`app/routes/web.py:185` — `total_pages = max(1, (total_count + page_size - 1) // page_size)` forced `total_pages` to 1 even when `total_count` was 0. The template rendered the pagination summary unconditionally, producing "Page 1 / 1" for empty result sets.

## Fix
- `app/routes/web.py`: change `total_pages` computation to return 0 when `total_count` is 0, so `normalized_page` also becomes 0 and `has_prev`/`has_next` are both `False`.
- `app/templates/index.html`: wrap the pagination summary `<p>` in `{% if run_page.total_count > 0 %}` so it never renders for empty result sets.
- `tests/test_web_runs.py`: add `test_fetch_runs_total_pages_zero_when_empty` asserting correct zero-state values.

## Verification
```
PYTHONPATH=. python -m pytest tests/test_web_runs.py -v  # 11 passed
PYTHONPATH=. python -m pytest tests/ -v                   # 517 passed, 4 pre-existing failures (missing `gh` CLI)
```
Manual verification: empty DB → "No runs yet." with no pagination line; 3 runs → "Showing 3 of 3 runs · Page 1 / 1".

Fixes #216